### PR TITLE
Pass a Custom Predicate for HealthKit Data Collection

### DIFF
--- a/Sources/SpeziHealthKit/CollectSample/CollectSample.swift
+++ b/Sources/SpeziHealthKit/CollectSample/CollectSample.swift
@@ -22,9 +22,16 @@ public struct CollectSample: HealthKitDataSourceDescription {
     
     /// - Parameters:
     ///   - sampleType: The `HKSampleType` that should be collected
+    ///   - predicate: A custom predicate that should be passed to the HealthKit query.
+    ///                The default predicate collects all samples that have been collected from the first time that the user
+    ///                provided the application authorization to collect the samples.
     ///   - deliverySetting: The ``HealthKitDeliverySetting`` that should be used to collect the sample type. `.manual` is the default argument used.
-    public init<S: HKSampleType>(_ sampleType: S, deliverySetting: HealthKitDeliverySetting = .manual()) {
-        self.collectSamples = CollectSamples([sampleType], deliverySetting: deliverySetting)
+    public init<S: HKSampleType>(
+        _ sampleType: S,
+        predicate: NSPredicate? = nil,
+        deliverySetting: HealthKitDeliverySetting = .manual()
+    ) {
+        self.collectSamples = CollectSamples([sampleType], predicate: predicate, deliverySetting: deliverySetting)
     }
     
     

--- a/Sources/SpeziHealthKit/CollectSample/CollectSamples.swift
+++ b/Sources/SpeziHealthKit/CollectSample/CollectSamples.swift
@@ -13,14 +13,23 @@ import Spezi
 /// Collects `HKSampleType`s  in the ``HealthKit`` component.
 public struct CollectSamples: HealthKitDataSourceDescription {
     public let sampleTypes: Set<HKSampleType>
+    let predicate: NSPredicate?
     let deliverySetting: HealthKitDeliverySetting
     
     
     /// - Parameters:
     ///   - sampleType: The set of `HKSampleType`s that should be collected
+    ///   - predicate: A custom predicate that should be passed to the HealthKit query.
+    ///                The default predicate collects all samples that have been collected from the first time that the user
+    ///                provided the application authorization to collect the samples.
     ///   - deliverySetting: The ``HealthKitDeliverySetting`` that should be used to collect the sample type. `.manual` is the default argument used.
-    public init(_ sampleTypes: Set<HKSampleType>, deliverySetting: HealthKitDeliverySetting = .manual()) {
+    public init(
+        _ sampleTypes: Set<HKSampleType>,
+        predicate: NSPredicate? = nil,
+        deliverySetting: HealthKitDeliverySetting = .manual()
+    ) {
         self.sampleTypes = sampleTypes
+        self.predicate = predicate
         self.deliverySetting = deliverySetting
     }
     
@@ -35,6 +44,7 @@ public struct CollectSamples: HealthKitDataSourceDescription {
                 healthStore: healthStore,
                 standard: standard,
                 sampleType: sampleType,
+                predicate: predicate,
                 deliverySetting: deliverySetting,
                 adapter: adapter
             )

--- a/Sources/SpeziHealthKit/HealthKit.swift
+++ b/Sources/SpeziHealthKit/HealthKit.swift
@@ -98,22 +98,21 @@ public final class HealthKit<ComponentStandard: Standard>: Module {
     /// Displays the user interface to ask for authorization for all HealthKit data defined by the ``HealthKitDataSourceDescription``s.
     ///
     /// Call this function when you want to start HealthKit data collection.
-    /// - Parameter objectTypes: Additional `HKObjectType` instances that should be authorized.
-    public func askForAuthorization(_ objectTypes: Set<HKObjectType> = []) async throws {
-        var objectTypes: Set<HKSampleType> = []
+    public func askForAuthorization() async throws {
+        var sampleTypes: Set<HKSampleType> = []
         
         for healthKitDataSourceDescription in healthKitDataSourceDescriptions {
-            objectTypes = objectTypes.union(healthKitDataSourceDescription.sampleTypes)
+            sampleTypes = sampleTypes.union(healthKitDataSourceDescription.sampleTypes)
         }
         
         let requestedSampleTypes = Set(UserDefaults.standard.stringArray(forKey: UserDefaults.Keys.healthKitRequestedSampleTypes) ?? [])
-        guard !Set(objectTypes.map { $0.identifier }).isSubset(of: requestedSampleTypes) else {
+        guard !Set(sampleTypes.map { $0.identifier }).isSubset(of: requestedSampleTypes) else {
             return
         }
         
-        try await healthStore.requestAuthorization(toShare: [], read: objectTypes)
+        try await healthStore.requestAuthorization(toShare: [], read: sampleTypes)
         
-        UserDefaults.standard.set(objectTypes.map { $0.identifier }, forKey: UserDefaults.Keys.healthKitRequestedSampleTypes)
+        UserDefaults.standard.set(sampleTypes.map { $0.identifier }, forKey: UserDefaults.Keys.healthKitRequestedSampleTypes)
         
         for healthKitComponent in healthKitComponents {
             healthKitComponent.askedForAuthorization()

--- a/Sources/SpeziHealthKit/HealthKit.swift
+++ b/Sources/SpeziHealthKit/HealthKit.swift
@@ -98,21 +98,22 @@ public final class HealthKit<ComponentStandard: Standard>: Module {
     /// Displays the user interface to ask for authorization for all HealthKit data defined by the ``HealthKitDataSourceDescription``s.
     ///
     /// Call this function when you want to start HealthKit data collection.
-    public func askForAuthorization() async throws {
-        var sampleTypes: Set<HKSampleType> = []
+    /// - Parameter objectTypes: Additional `HKObjectType` instances that should be authorized.
+    public func askForAuthorization(_ objectTypes: Set<HKObjectType> = []) async throws {
+        var objectTypes: Set<HKSampleType> = []
         
         for healthKitDataSourceDescription in healthKitDataSourceDescriptions {
-            sampleTypes = sampleTypes.union(healthKitDataSourceDescription.sampleTypes)
+            objectTypes = objectTypes.union(healthKitDataSourceDescription.sampleTypes)
         }
         
         let requestedSampleTypes = Set(UserDefaults.standard.stringArray(forKey: UserDefaults.Keys.healthKitRequestedSampleTypes) ?? [])
-        guard !Set(sampleTypes.map { $0.identifier }).isSubset(of: requestedSampleTypes) else {
+        guard !Set(objectTypes.map { $0.identifier }).isSubset(of: requestedSampleTypes) else {
             return
         }
         
-        try await healthStore.requestAuthorization(toShare: [], read: sampleTypes)
+        try await healthStore.requestAuthorization(toShare: [], read: objectTypes)
         
-        UserDefaults.standard.set(sampleTypes.map { $0.identifier }, forKey: UserDefaults.Keys.healthKitRequestedSampleTypes)
+        UserDefaults.standard.set(objectTypes.map { $0.identifier }, forKey: UserDefaults.Keys.healthKitRequestedSampleTypes)
         
         for healthKitComponent in healthKitComponents {
             healthKitComponent.askedForAuthorization()


### PR DESCRIPTION
# Pass a Custom Predicate for HealthKit Data Collection

## :recycle: Current situation & Problem
- The HealthKit module currently only collects samples that have been added after the user has first granted consent to the application.

## :bulb: Proposed solution
- Adds a predicate to further control the collection of HealthKit data


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
