### PR TITLE
Improve Public Interface using Explicit Export of HealthKit

### DIFF
--- a/Sources/SpeziHealthKit/Export.swift
+++ b/Sources/SpeziHealthKit/Export.swift
@@ -1,0 +1,9 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+@_exported import HealthKit

--- a/Tests/UITests/TestApp/ExampleStandard.swift
+++ b/Tests/UITests/TestApp/ExampleStandard.swift
@@ -16,6 +16,7 @@ actor ExampleStandard: Standard, ObservableObject, ObservableObjectProvider {
     @Published @MainActor var addedResponses = [HKSample]()
 }
 
+
 extension ExampleStandard: HealthKitConstraint {
     func add(sample: HKSample) async {
         _Concurrency.Task { @MainActor in

--- a/Tests/UITests/TestApp/HealthKitTestsView.swift
+++ b/Tests/UITests/TestApp/HealthKitTestsView.swift
@@ -6,11 +6,8 @@
 // SPDX-License-Identifier: MIT
 //
 
-import Combine
-import HealthKit
 import SpeziHealthKit
 import SwiftUI
-import XCTSpezi
 
 
 struct HealthKitTestsView: View {
@@ -22,8 +19,7 @@ struct HealthKitTestsView: View {
         Button("Ask for authorization") {
             askForAuthorization()
         }
-        .disabled(healthKitComponent.authorized)
-        
+            .disabled(healthKitComponent.authorized)
         Button("Trigger data source collection") {
             triggerDataSourceCollection()
         }

--- a/Tests/UITests/TestApp/TestAppDelegate.swift
+++ b/Tests/UITests/TestApp/TestAppDelegate.swift
@@ -6,10 +6,8 @@
 // SPDX-License-Identifier: MIT
 //
 
-@preconcurrency import HealthKit
 import Spezi
 import SpeziHealthKit
-import XCTSpezi
 
 
 class TestAppDelegate: SpeziAppDelegate {

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -13,7 +13,6 @@
 		2F85827129E776780021D637 /* HealthKitTestsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F85827029E776780021D637 /* HealthKitTestsView.swift */; };
 		2F85827329E776AC0021D637 /* TestAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F85827229E776AC0021D637 /* TestAppDelegate.swift */; };
 		2F85827629E776D10021D637 /* Spezi in Frameworks */ = {isa = PBXBuildFile; productRef = 2F85827529E776D10021D637 /* Spezi */; };
-		2F85827829E776D10021D637 /* XCTSpezi in Frameworks */ = {isa = PBXBuildFile; productRef = 2F85827729E776D10021D637 /* XCTSpezi */; };
 		2F85827F29E7782C0021D637 /* XCTestExtensions in Frameworks */ = {isa = PBXBuildFile; productRef = 2F85827E29E7782C0021D637 /* XCTestExtensions */; };
 		2FA7382C290ADFAA007ACEB9 /* TestApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA7382B290ADFAA007ACEB9 /* TestApp.swift */; };
 		390F29612A785A98000A236E /* ExampleStandard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 390F29602A785A98000A236E /* ExampleStandard.swift */; };
@@ -49,7 +48,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2F85827829E776D10021D637 /* XCTSpezi in Frameworks */,
 				2F61BDC329DD02D600D71D33 /* SpeziHealthKit in Frameworks */,
 				2F85827629E776D10021D637 /* Spezi in Frameworks */,
 			);
@@ -136,7 +134,6 @@
 			packageProductDependencies = (
 				2F61BDC229DD02D600D71D33 /* SpeziHealthKit */,
 				2F85827529E776D10021D637 /* Spezi */,
-				2F85827729E776D10021D637 /* XCTSpezi */,
 			);
 			productName = Example;
 			productReference = 2F6D139228F5F384007C25D6 /* TestApp.app */;
@@ -683,11 +680,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 2F85827429E776D10021D637 /* XCRemoteSwiftPackageReference "Spezi" */;
 			productName = Spezi;
-		};
-		2F85827729E776D10021D637 /* XCTSpezi */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 2F85827429E776D10021D637 /* XCRemoteSwiftPackageReference "Spezi" */;
-			productName = XCTSpezi;
 		};
 		2F85827E29E7782C0021D637 /* XCTestExtensions */ = {
 			isa = XCSwiftPackageProductDependency;


### PR DESCRIPTION
# Improve Public Interface using Explicit Export of HealthKit

## :recycle: Current situation & Problem
- Using SpeziHealthKit requires importing HealthKit to ensure that the host application understands the offered APIs. 

## :bulb: Proposed solution
- Explicitly exports HealthKit in the API surface.


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
