### PR TITLE
Allow the Execution of HealthKit Queries Outside of the Configuration

### DIFF
--- a/Sources/SpeziHealthKit/CollectSample/HealthKitSampleDataSource.swift
+++ b/Sources/SpeziHealthKit/CollectSample/HealthKitSampleDataSource.swift
@@ -84,7 +84,7 @@ final class HealthKitSampleDataSource: HealthKitDataSource {
         }
     }
     
-    func willFinishLaunchingWithOptions(_ application: UIApplication, launchOptions: [UIApplication.LaunchOptionsKey: Any]) {
+    func willFinishLaunchingWithOptions() {
         guard askedForAuthorization(for: sampleType) else {
             return
         }

--- a/Sources/SpeziHealthKit/HealthKit.swift
+++ b/Sources/SpeziHealthKit/HealthKit.swift
@@ -64,10 +64,10 @@ import SwiftUI
 /// }
 /// ```
 @Observable
-public final class HealthKit: Module, LifecycleHandler, EnvironmentAccessible {
+public final class HealthKit: Module, LifecycleHandler, EnvironmentAccessible, DefaultInitializable {
     @ObservationIgnored @StandardActor private var standard: any HealthKitConstraint
     private let healthStore: HKHealthStore
-    private var healthKitDataSourceDescriptions: [HealthKitDataSourceDescription]
+    private var healthKitDataSourceDescriptions: [HealthKitDataSourceDescription] = []
     @ObservationIgnored private lazy var healthKitComponents: [any HealthKitDataSource] = {
         healthKitDataSourceDescriptions
             .flatMap { $0.dataSources(healthStore: healthStore, standard: standard) }
@@ -104,9 +104,15 @@ public final class HealthKit: Module, LifecycleHandler, EnvironmentAccessible {
     /// Creates a new instance of the ``HealthKit`` module.
     /// - Parameters:
     ///   - healthKitDataSourceDescriptions: The ``HealthKitDataSourceDescription``s define what data is collected by the ``HealthKit`` module. You can, e.g., use ``CollectSample`` to collect a wide variety of `HKSampleTypes`.
-    public init(
+    public convenience init(
         @HealthKitDataSourceDescriptionBuilder _ healthKitDataSourceDescriptions: () -> [HealthKitDataSourceDescription]
     ) {
+        self.init()
+        
+        self.healthKitDataSourceDescriptions = healthKitDataSourceDescriptions()
+    }
+    
+    public init() {
         precondition(
             HKHealthStore.isHealthDataAvailable(),
             """
@@ -119,11 +125,7 @@ public final class HealthKit: Module, LifecycleHandler, EnvironmentAccessible {
             """
         )
         
-        let healthStore = HKHealthStore()
-        let healthKitDataSourceDescriptions = healthKitDataSourceDescriptions()
-        
-        self.healthKitDataSourceDescriptions = healthKitDataSourceDescriptions
-        self.healthStore = healthStore
+        self.healthStore = HKHealthStore()
     }
     
     

--- a/Sources/SpeziHealthKit/HealthKitDataSource/HealthKitDataSource.swift
+++ b/Sources/SpeziHealthKit/HealthKitDataSource/HealthKitDataSource.swift
@@ -11,9 +11,14 @@ import Spezi
 import SwiftUI
 
 
-public protocol HealthKitDataSource: LifecycleHandler {
+/// Requirement for every HealthKit Data Source.
+public protocol HealthKitDataSource {
+    /// Called after the used was asked for authorization.
     func askedForAuthorization()
+    /// Called to trigger the manual data collection.
     func triggerDataSourceCollection() async
+    /// Called when the application finished launching with options.
+    func willFinishLaunchingWithOptions()
 }
 
 


### PR DESCRIPTION
# Allow the Execution of HealthKit Queries Outside of the Configuration


## :gear: Release Notes 
- Enables the execution of HealthKit queries outside of the configuration
- Simplifies the logic in the HealthKit module, make information private, and let the module conform to `DefaultInitializable`.



## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
