### PR TITLE
Add Documentation Catalog and bump to Spezi 1.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .library(name: "SpeziHealthKit", targets: ["SpeziHealthKit"])
     ],
     dependencies: [
-        .package(url: "https://github.com/StanfordSpezi/Spezi", .upToNextMinor(from: "0.8.0"))
+        .package(url: "https://github.com/StanfordSpezi/Spezi", from: "1.0.0")
     ],
     targets: [
         .target(

--- a/README.md
+++ b/README.md
@@ -16,10 +16,74 @@ SPDX-License-Identifier: MIT
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FStanfordSpezi%2FSpeziHealthKit%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/StanfordSpezi/SpeziHealthKit)
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FStanfordSpezi%2FSpeziHealthKit%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/StanfordSpezi/SpeziHealthKit)
 
+Simplifies access to HealthKit samples ranging from single, anchored, and background queries.
+
+## Overview
+
 The Spezi HealthKit module simplifies access to HealthKit samples ranging from single, anchored, and background queries.
 
-For more information, please refer to the [API documentation](https://swiftpackageindex.com/StanfordSpezi/SpeziHealthKit/documentation).
+### Setup
 
+You need to add the Spezi HealthKit Swift package to
+[your app in Xcode](https://developer.apple.com/documentation/xcode/adding-package-dependencies-to-your-app) or
+[Swift package](https://developer.apple.com/documentation/xcode/creating-a-standalone-swift-package-with-xcode#Add-a-dependency-on-another-Swift-package).
+
+> Important: If your application is not yet configured to use Spezi, follow the
+[Spezi setup article](https://swiftpackageindex.com/stanfordspezi/spezi/documentation/spezi/initial-setup) and set up the core Spezi infrastructure.
+
+### Example
+
+Before you configure the ``HealthKit`` module, make sure your `Standard` in your Spezi Application conforms to the ``HealthKitConstraint`` protocol to receive HealthKit data.
+```swift
+actor ExampleStandard: Standard, HealthKitConstraint {
+    func add(sample: HKSample) async {
+        // ...
+    }
+
+    func remove(sample: HKDeletedObject) {
+        // ...
+    }
+}
+```
+
+
+Then, you can configure the ``HealthKit`` module in the configuration section of your `SpeziAppDelegate`.
+Provide ``HealthKitDataSourceDescription`` to define the data collection.
+You can, e.g., use ``CollectSample`` to collect a wide variety of `HKSampleTypes`:
+```swift
+class ExampleAppDelegate: SpeziAppDelegate {
+    override var configuration: Configuration {
+        Configuration(standard: ExampleStandard()) {
+            if HKHealthStore.isHealthDataAvailable() {
+                HealthKit {
+                    CollectSample(
+                        HKQuantityType.electrocardiogramType(),
+                        deliverySetting: .background(.manual)
+                    )
+                    CollectSample(
+                        HKQuantityType(.stepCount),
+                        deliverySetting: .background(.afterAuthorizationAndApplicationWillLaunch)
+                    )
+                    CollectSample(
+                        HKQuantityType(.pushCount),
+                        deliverySetting: .anchorQuery(.manual)
+                    )
+                    CollectSample(
+                        HKQuantityType(.activeEnergyBurned),
+                        deliverySetting: .anchorQuery(.afterAuthorizationAndApplicationWillLaunch)
+                    )
+                    CollectSample(
+                        HKQuantityType(.restingHeartRate),
+                        deliverySetting: .manual()
+                    )
+                }
+            }
+        }
+    }
+}
+```
+
+For more information, please refer to the [API documentation](https://swiftpackageindex.com/StanfordSpezi/SpeziHealthKit/documentation).
 
 ## The Spezi Template Application
 

--- a/Sources/SpeziHealthKit/HealthKit.swift
+++ b/Sources/SpeziHealthKit/HealthKit.swift
@@ -11,12 +11,11 @@ import Spezi
 import SwiftUI
 
 
-/// The ``HealthKit`` module enables the collection of HealthKit data.
+/// The `HealthKit` module enables the collection of HealthKit data.
 ///
-/// Configuration for the ``SpeziHealthKit`` module.
+/// The `HealthKit` module simplifies access to HealthKit samples ranging from single, anchored, and background queries.
 ///
-/// Make sure that your standard in your Spezi Application conforms to the ``HealthKitConstraint``
-/// protocol to receive HealthKit data.
+/// Before you configure the ``HealthKit`` module, make sure your `Standard` in your Spezi Application conforms to the ``HealthKitConstraint`` protocol to receive HealthKit data.
 /// ```swift
 /// actor ExampleStandard: Standard, HealthKitConstraint {
 ///    func add(sample: HKSample) async {
@@ -28,8 +27,9 @@ import SwiftUI
 ///    }
 /// }
 /// ```
-///
-/// Use the ``HealthKit/init(_:)`` initializer to define different ``HealthKitDataSourceDescription``s to define the data collection.
+/// 
+/// Then, you can configure the ``HealthKit`` module in the configuration section of your `SpeziAppDelegate`.
+/// Provide ``HealthKitDataSourceDescription`` to define the data collection.
 /// You can, e.g., use ``CollectSample`` to collect a wide variety of `HKSampleTypes`:
 /// ```swift
 /// class ExampleAppDelegate: SpeziAppDelegate {

--- a/Sources/SpeziHealthKit/SpeziHealthKit.docc/SpeziHealthKit.md
+++ b/Sources/SpeziHealthKit/SpeziHealthKit.docc/SpeziHealthKit.md
@@ -1,0 +1,99 @@
+# ``SpeziHealthKit``
+
+<!--
+#
+# This source file is part of the Stanford Spezi open source project
+#
+# SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+#
+# SPDX-License-Identifier: MIT
+#       
+-->
+
+Simplified access to HealthKit samples ranging from single, anchored, and background queries.
+
+## Overview
+
+The Spezi HealthKit module simplifies access to HealthKit samples ranging from single, anchored, and background queries.
+
+### Setup
+
+You need to add the Spezi HealthKit Swift package to
+ [your app in Xcode](https://developer.apple.com/documentation/xcode/adding-package-dependencies-to-your-app) or
+ [Swift package](https://developer.apple.com/documentation/xcode/creating-a-standalone-swift-package-with-xcode#Add-a-dependency-on-another-Swift-package).
+
+> Important: If your application is not yet configured to use Spezi, follow the
+ [Spezi setup article](https://swiftpackageindex.com/stanfordspezi/spezi/documentation/spezi/initial-setup) and set up the core Spezi infrastructure.
+
+### Example
+
+Before you configure the ``HealthKit`` module, make sure your `Standard` in your Spezi Application conforms to the ``HealthKitConstraint`` protocol to receive HealthKit data.
+```swift
+actor ExampleStandard: Standard, HealthKitConstraint {
+    func add(sample: HKSample) async {
+        // ...
+    }
+
+    func remove(sample: HKDeletedObject) {
+        // ...
+    }
+}
+```
+
+
+Then, you can configure the ``HealthKit`` module in the configuration section of your `SpeziAppDelegate`.
+Provide ``HealthKitDataSourceDescription`` to define the data collection.
+You can, e.g., use ``CollectSample`` to collect a wide variety of `HKSampleTypes`:
+```swift
+class ExampleAppDelegate: SpeziAppDelegate {
+    override var configuration: Configuration {
+        Configuration(standard: ExampleStandard()) {
+            if HKHealthStore.isHealthDataAvailable() {
+                HealthKit {
+                    CollectSample(
+                        HKQuantityType.electrocardiogramType(),
+                        deliverySetting: .background(.manual)
+                    )
+                    CollectSample(
+                        HKQuantityType(.stepCount),
+                        deliverySetting: .background(.afterAuthorizationAndApplicationWillLaunch)
+                    )
+                    CollectSample(
+                        HKQuantityType(.pushCount),
+                        deliverySetting: .anchorQuery(.manual)
+                    )
+                    CollectSample(
+                        HKQuantityType(.activeEnergyBurned),
+                        deliverySetting: .anchorQuery(.afterAuthorizationAndApplicationWillLaunch)
+                    )
+                    CollectSample(
+                        HKQuantityType(.restingHeartRate),
+                        deliverySetting: .manual()
+                    )
+                }
+            }
+        }
+    }
+}
+```
+
+## Topics
+
+### Module
+
+- ``HealthKit``
+- ``HealthKitConstraint``
+
+### Data Sources
+
+- ``HealthKitDataSourceDescription``
+- ``HealthKitDataSourceDescriptionBuilder``
+- ``HealthKitDataSource``
+
+### Collecting Samples
+
+- ``CollectSample``
+- ``CollectSamples``
+- ``HealthKitDeliverySetting``
+- ``HealthKitDeliveryStartSetting``
+


### PR DESCRIPTION
# Add Documentation Catalog and bump to Spezi 1.0

## :recycle: Current situation & Problem
This PR improves documentation by adding a DocC documentation catalog. Further, we upgrade the package to the latest Spezi 1.0 release.


## :gear: Release Notes 
* Add proper documentation landing page
* Upgrade to Spezi 1.0 releases

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
