### PR TITLE
Fixes Crashing When Using Background Requests

### DIFF
--- a/Sources/SpeziHealthKit/HealthKit Extensions/HKHealthStore+Observations.swift
+++ b/Sources/SpeziHealthKit/HealthKit Extensions/HKHealthStore+Observations.swift
@@ -49,9 +49,7 @@ extension HKHealthStore {
                 
                 continuation.onTermination = { @Sendable _ in
                     self.stop(observerQuery)
-                    Task {
-                        await self.disableBackgroundDelivery(for: sampleTypes)
-                    }
+                    self.disableBackgroundDelivery(for: sampleTypes)
                 }
             }
         }
@@ -75,14 +73,14 @@ extension HKHealthStore {
             }
         } catch {
             // Revert all changes as enable background delivery for the object types failed.
-            await disableBackgroundDelivery(for: enabledObjectTypes)
+            disableBackgroundDelivery(for: enabledObjectTypes)
         }
     }
     
     
     func disableBackgroundDelivery(
         for objectTypes: Set<HKObjectType>
-    ) async {
+    ) {
         for objectType in objectTypes {
             Self.activeObservationsLock.withLock {
                 if let activeObservation = HKHealthStore.activeObservations[objectType] {


### PR DESCRIPTION
# Fixes Crashing When Using Background Requests

## :recycle: Current situation & Problem
- if a developer uses multiple HealthKit queries in the background data races accessing the tracked background activations can lead to runtime crashes.


## :gear: Release Notes 
- Fixes the issue using additional locking mechanisms

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
