### PR TITLE
Deferred Sample Collection; Improved Handling of Duplicate/Overlapping `CollectSample` Definitions

### DIFF
--- a/Sources/SpeziHealthKit/Configuration/HealthKitConfiguration.swift
+++ b/Sources/SpeziHealthKit/Configuration/HealthKitConfiguration.swift
@@ -56,5 +56,10 @@ extension HealthKit {
         public mutating func merge(with other: Self) {
             self = self.merging(with: other)
         }
+        
+        /// Whether the data access requirements is empty
+        public var isEmpty: Bool {
+            read.isEmpty && write.isEmpty
+        }
     }
 }

--- a/Sources/SpeziHealthKit/Health Data Collection/HealthDataCollector.swift
+++ b/Sources/SpeziHealthKit/Health Data Collection/HealthDataCollector.swift
@@ -40,4 +40,15 @@ public protocol HealthDataCollector: AnyObject {
     /// Called to inform the collector that it should start collecting data.
     @MainActor
     func startDataCollection() async
+    
+    /// Tells the data collector to stop its data collection.
+    @MainActor
+    func stopDataCollection() async
+}
+
+
+extension HealthDataCollector {
+    var typeErasedSampleType: any AnySampleType {
+        sampleType
+    }
 }

--- a/Sources/SpeziHealthKit/HealthKit Extensions/HKHealthStore+AnchoredObjectQuery.swift
+++ b/Sources/SpeziHealthKit/HealthKit Extensions/HKHealthStore+AnchoredObjectQuery.swift
@@ -21,8 +21,8 @@ extension HKHealthStore {
     @MainActor
     func anchoredSingleObjectQuery(
         for sampleType: HKSampleType,
-        using anchor: HKQueryAnchor? = nil, // swiftlint:disable:this function_default_parameter_at_end
-        withPredicate predicate: NSPredicate? = nil, // swiftlint:disable:this function_default_parameter_at_end
+        using anchor: HKQueryAnchor?,
+        withPredicate predicate: NSPredicate?,
         standard: any HealthKitConstraint
     ) async throws -> HKQueryAnchor {
         let anchorDescriptor = anchorDescriptor(sampleType: sampleType, predicate: predicate, anchor: anchor)

--- a/Sources/SpeziHealthKit/HealthKit Extensions/HKHealthStore+BackgroundDelivery.swift
+++ b/Sources/SpeziHealthKit/HealthKit Extensions/HKHealthStore+BackgroundDelivery.swift
@@ -12,9 +12,6 @@ import Spezi
 
 
 extension HKHealthStore {
-    private static let activeObservationsLock = NSLock()
-    private static nonisolated(unsafe) var activeObservations: [HKObjectType: Int] = [:]
-    
     final class BackgroundObserverQueryInvalidator: @unchecked Sendable {
         private let healthStore: HKHealthStore
         private weak var query: HKQuery?
@@ -30,6 +27,9 @@ extension HKHealthStore {
             }
         }
     }
+    
+    private static let activeObservationsLock = NSLock()
+    private static nonisolated(unsafe) var activeObservations: [HKObjectType: Int] = [:]
     
     @MainActor @discardableResult
     func startBackgroundDelivery(

--- a/Sources/SpeziHealthKit/HealthKit.swift
+++ b/Sources/SpeziHealthKit/HealthKit.swift
@@ -132,11 +132,13 @@ public final class HealthKit: Module, EnvironmentAccessible, DefaultInitializabl
         guard HKHealthStore.isHealthDataAvailable() else {
             return
         }
-        self.dataAccessRequirements.merge(with: accessRequirements)
-        try await healthStore.requestAuthorization(
-            toShare: accessRequirements.write,
-            read: accessRequirements.read
-        )
+        if !accessRequirements.isEmpty {
+            self.dataAccessRequirements.merge(with: accessRequirements)
+            try await healthStore.requestAuthorization(
+                toShare: accessRequirements.write,
+                read: accessRequirements.read
+            )
+        }
         for collector in registeredDataCollectors {
             await startAutomaticDataCollectionIfPossible(collector)
         }

--- a/Sources/SpeziHealthKit/HealthKit.swift
+++ b/Sources/SpeziHealthKit/HealthKit.swift
@@ -40,6 +40,9 @@ public final class HealthKit: Module, EnvironmentAccessible, DefaultInitializabl
     /// Which HealthKit data we need to be able to access, for read and/or write operations.
     private var dataAccessRequirements: DataAccessRequirements
     
+    /// Whether the module has already been configured.
+    @ObservationIgnored private var didConfigure = false
+    
     /// Configurations which were supplied to the initializer, but have not yet been applied.
     /// - Note: This property is intended only to store the configuration until `configure()` has been called. It is not used afterwards.
     @ObservationIgnored private var pendingConfiguration: [any HealthKitConfigurationComponent]
@@ -84,6 +87,7 @@ public final class HealthKit: Module, EnvironmentAccessible, DefaultInitializabl
     @_documentation(visibility: internal)
     public func configure() {
         Task {
+            didConfigure = true
             for component in exchange(&pendingConfiguration, with: []) {
                 await component.configure(for: self, on: self.standard)
             }
@@ -227,14 +231,64 @@ extension HealthKit { // swiftlint:disable:this file_types_order
         }
     }
     
+    /// Adds a new ``CollectSample`` definition to the module.
+    ///
+    /// Calling this function is equivalent to including the ``CollectSample`` definition in the initial module configuration.
+    @MainActor
+    public func addHealthDataCollector(_ collectSample: CollectSample<some Any>) async {
+        if !didConfigure {
+            pendingConfiguration.append(collectSample)
+        } else {
+            await collectSample.configure(for: self, on: standard)
+        }
+    }
+    
     /// Adds a new data source for collecting health data in the background.
     ///
     /// If the user was already asked for access to this collector's sample type, the collector will immediately be informed to
     /// start its automatic data collection.
     @MainActor
-    public func addHealthDataCollector(_ collector: some HealthDataCollector) async {
-        registeredDataCollectors.append(collector)
-        await startAutomaticDataCollectionIfPossible(collector)
+    public func addHealthDataCollector(_ newCollector: any HealthDataCollector) async {
+        enum Action {
+            case add
+            case dontAdd
+            case replace(index: Int)
+        }
+        let action: Action = { () -> Action in
+            // Determine, based on the existing currently-registered collectors, how this one should be handled.
+            for (idx, existingCollector) in self.registeredDataCollectors.enumerated() {
+                guard existingCollector.typeErasedSampleType == newCollector.typeErasedSampleType else {
+                    continue
+                }
+                if existingCollector.deliverySetting == newCollector.deliverySetting {
+                    // the existing collector has the same sample type and delivery setting as the new one
+                    // -> there's no need to add the new one (we already have an identical one)
+                    return .dontAdd
+                } else if existingCollector.deliverySetting.continueInBackground && !newCollector.deliverySetting.continueInBackground {
+                    // we have an existing one which is supposed to run in the background, and a new one which is not.
+                    // -> the background-enabled one can subsume the new one
+                    return .dontAdd
+                } else if !existingCollector.deliverySetting.continueInBackground && newCollector.deliverySetting.continueInBackground {
+                    // the existing collector is supposed to only run while the app is active, while the new one should also
+                    // continue in the background. we replace the existing one with the new one, thereby effectively subsuming it into the new one
+                    return .replace(index: idx)
+                }
+            }
+            // if none of the existing collectors matched against the new one (or if there weren't any existing ones),
+            // we want to add the new one.
+            return .add
+        }()
+        switch action {
+        case .dontAdd:
+            return
+        case .replace(let index):
+            await registeredDataCollectors[index].stopDataCollection()
+            registeredDataCollectors.remove(at: index)
+            fallthrough
+        case .add:
+            registeredDataCollectors.append(newCollector)
+            await startAutomaticDataCollectionIfPossible(newCollector)
+        }
     }
     
     

--- a/Sources/SpeziHealthKit/HealthKit.swift
+++ b/Sources/SpeziHealthKit/HealthKit.swift
@@ -241,6 +241,7 @@ extension HealthKit { // swiftlint:disable:this file_types_order
         if !didConfigure {
             pendingConfiguration.append(collectSample)
         } else {
+            dataAccessRequirements.merge(with: collectSample.dataAccessRequirements)
             await collectSample.configure(for: self, on: standard)
         }
     }

--- a/Sources/SpeziHealthKit/HealthKit.swift
+++ b/Sources/SpeziHealthKit/HealthKit.swift
@@ -48,7 +48,7 @@ public final class HealthKit: Module, EnvironmentAccessible, DefaultInitializabl
     @ObservationIgnored private var pendingConfiguration: [any HealthKitConfigurationComponent]
     
     /// All background-data-collecting data sources registered with the HealthKit module.
-    @ObservationIgnored private var registeredDataCollectors: [any HealthDataCollector] = []
+    @ObservationIgnored /* private-but-testable */ private(set) var registeredDataCollectors: [any HealthDataCollector] = []
     
     
     /// Creates a new instance of the ``HealthKit-class`` module, with the specified configuration.

--- a/Sources/SpeziHealthKit/Sample Types/AnySampleType.swift
+++ b/Sources/SpeziHealthKit/Sample Types/AnySampleType.swift
@@ -61,3 +61,13 @@ extension AnySampleType {
 @inlinable public func == (lhs: any AnySampleType, rhs: any AnySampleType) -> Bool { // swiftlint:disable:this static_operator
     lhs.id == rhs.id
 }
+
+/// Compare two type-erased sample type, based on their identifiers
+@inlinable public func == (lhs: any AnySampleType, rhs: SampleType<some Any>) -> Bool { // swiftlint:disable:this static_operator
+    lhs.id == rhs.id
+}
+
+/// Compare two type-erased sample type, based on their identifiers
+@inlinable public func == (lhs: SampleType<some Any>, rhs: any AnySampleType) -> Bool { // swiftlint:disable:this static_operator
+    lhs.id == rhs.id
+}

--- a/Sources/SpeziHealthKit/Sample Types/SampleTypes.swift
+++ b/Sources/SpeziHealthKit/Sample Types/SampleTypes.swift
@@ -31,7 +31,7 @@ import HealthKit
 
 // MARK: Quantity Types
 
-extension SampleType {
+extension SampleType where Sample == HKQuantitySample {
     /// A quantity sample type that measures the number of steps the user has taken.
     @inlinable public static var stepCount: SampleType<HKQuantitySample> {
         .quantity(
@@ -1168,7 +1168,7 @@ extension SampleType {
 
 // MARK: Category Types
 
-extension SampleType {
+extension SampleType where Sample == HKCategorySample {
     /// A category sample type that counts the number of hours in the day during which the user has stood and moved for at least one minute per hour.
     @inlinable public static var appleStandHour: SampleType<HKCategorySample> {
         .category(
@@ -1441,7 +1441,7 @@ extension SampleType {
 
 // MARK: Correlation Types
 
-extension SampleType {
+extension SampleType where Sample == HKCorrelation {
     /// The sample type representing blood pressure correlation samples
     @inlinable public static var bloodPressure: SampleType<HKCorrelation> {
         .correlation(

--- a/Sources/SpeziHealthKit/Sample Types/SampleTypes.swift.gyb
+++ b/Sources/SpeziHealthKit/Sample Types/SampleTypes.swift.gyb
@@ -973,7 +973,7 @@ import HealthKit
 
 // MARK: ${display_title} Types
 
-extension SampleType {
+extension SampleType where Sample == ${hk_class} {
 % for ty in types:
     /// ${ty.doc}
     @inlinable public static var ${ty.property_name}: SampleType<${hk_class}> {

--- a/Tests/SpeziHealthKitTests/HealthDataCollectorRegistrationTests.swift
+++ b/Tests/SpeziHealthKitTests/HealthDataCollectorRegistrationTests.swift
@@ -1,0 +1,70 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+
+import Spezi
+@testable import SpeziHealthKit
+import XCTest
+import XCTSpezi
+
+
+private actor TestStandard: Standard, HealthKitConstraint {
+    func add(sample: HKSample) async {}
+    func remove(sample: HKDeletedObject) async {}
+}
+
+
+final class HealthDataCollectorRegistrationTests: XCTestCase {
+    @MainActor
+    func testCollectSamplesRegistration() async throws {
+        let healthKit = HealthKit {
+            CollectSample(.heartRate)
+            CollectSample(.heartRate)
+            CollectSample(.stepCount, continueInBackground: false)
+            CollectSample(.stepCount, continueInBackground: true)
+        }
+        withDependencyResolution(standard: TestStandard()) {
+            healthKit
+        }
+        
+        var erasedCollectors: [AnyObject] = healthKit.registeredDataCollectors
+        
+        try await Task.sleep(for: .seconds(1))
+        XCTAssertEqual(healthKit.registeredDataCollectors.count, 2)
+        XCTAssertEqual(1, healthKit.registeredDataCollectors.count { $0.typeErasedSampleType == .heartRate })
+        
+        await healthKit.addHealthDataCollector(CollectSample(.bloodOxygen))
+        XCTAssertEqual(healthKit.registeredDataCollectors.count, 3)
+        
+        erasedCollectors = healthKit.registeredDataCollectors
+        await healthKit.addHealthDataCollector(CollectSample(.bloodOxygen))
+        XCTAssert(erasedCollectors.elementsEqual(healthKit.registeredDataCollectors, by: ===))
+        XCTAssertEqual(healthKit.registeredDataCollectors.count, 3)
+        
+        await healthKit.addHealthDataCollector(CollectSample(.walkingStepLength, continueInBackground: true))
+        XCTAssertEqual(healthKit.registeredDataCollectors.count, 4)
+        erasedCollectors = healthKit.registeredDataCollectors
+        await healthKit.addHealthDataCollector(CollectSample(.walkingStepLength, continueInBackground: true))
+        // nothing should change, since the new collector is equal to an existing one.
+        XCTAssertEqual(healthKit.registeredDataCollectors.count, 4)
+        XCTAssert(erasedCollectors.elementsEqual(healthKit.registeredDataCollectors, by: ===))
+        await healthKit.addHealthDataCollector(CollectSample(.walkingStepLength, continueInBackground: false))
+        // nothing should change, since the new (non-bg) collector will get subsumed into the existing (bg) one.
+        XCTAssertEqual(healthKit.registeredDataCollectors.count, 4)
+        XCTAssert(erasedCollectors.elementsEqual(healthKit.registeredDataCollectors, by: ===))
+        
+        await healthKit.addHealthDataCollector(CollectSample(.height, continueInBackground: false))
+        XCTAssertEqual(healthKit.registeredDataCollectors.count, 5)
+        erasedCollectors = healthKit.registeredDataCollectors
+        await healthKit.addHealthDataCollector(CollectSample(.height, continueInBackground: true))
+        // we expect the second height collector to replace the first (background vs non-background),
+        // so the #collectors will remain the same, but they won't compare equal anymore
+        XCTAssertEqual(healthKit.registeredDataCollectors.count, 5)
+        XCTAssertFalse(erasedCollectors.elementsEqual(healthKit.registeredDataCollectors, by: ===))
+    }
+}

--- a/Tests/UITests/TestApp/HealthKitTestsView/HealthKitTestsView.swift
+++ b/Tests/UITests/TestApp/HealthKitTestsView/HealthKitTestsView.swift
@@ -23,7 +23,7 @@ struct HealthKitTestsView: View {
     private var bloodOxygenSamples
     
     var body: some View {
-        Form {
+        Form { // swiftlint:disable:this closure_body_length
             Section {
                 AsyncButton("Ask for authorization", state: $viewState) {
                     try? await healthKit.askForAuthorization()
@@ -34,6 +34,11 @@ struct HealthKitTestsView: View {
                     let start = ContinuousClock.now
                     await healthKit.triggerDataSourceCollection()
                     try await Task.sleep(until: start + .seconds(2)) // pretend that the data source triggering takes at least 2 seconds.
+                }
+                AsyncButton("Register additional CollectSample instances") {
+                    // we have matching ones for these in the AppDelegate, and we now add the resp reverse, to check the subsumption.
+                    await healthKit.addHealthDataCollector(CollectSample(.stairAscentSpeed, continueInBackground: false))
+                    await healthKit.addHealthDataCollector(CollectSample(.stairDescentSpeed, continueInBackground: true))
                 }
             }
             Section {

--- a/Tests/UITests/TestApp/TestAppDelegate.swift
+++ b/Tests/UITests/TestApp/TestAppDelegate.swift
@@ -34,6 +34,9 @@ class TestAppDelegate: SpeziAppDelegate {
                 CollectSample(.heartRate, start: .manual)
                 CollectSample(.heartRate, start: .manual)
                 
+                CollectSample(.stairAscentSpeed, continueInBackground: true)
+                CollectSample(.stairDescentSpeed, continueInBackground: false)
+                
                 RequestReadAccess(
                     quantity: [.bloodOxygen],
                     correlation: [.bloodPressure],

--- a/Tests/UITests/TestApp/TestAppDelegate.swift
+++ b/Tests/UITests/TestApp/TestAppDelegate.swift
@@ -31,7 +31,8 @@ class TestAppDelegate: SpeziAppDelegate {
                 CollectSample(
                     .activeEnergyBurned
                 )
-                CollectSample(.heartRate, start: .manual)
+                CollectSample(.heartRate, start: .automatic)
+                CollectSample(.heartRate, start: .automatic)
                 
                 RequestReadAccess(
                     quantity: [.bloodOxygen],

--- a/Tests/UITests/TestApp/TestAppDelegate.swift
+++ b/Tests/UITests/TestApp/TestAppDelegate.swift
@@ -31,8 +31,8 @@ class TestAppDelegate: SpeziAppDelegate {
                 CollectSample(
                     .activeEnergyBurned
                 )
-                CollectSample(.heartRate, start: .automatic)
-                CollectSample(.heartRate, start: .automatic)
+                CollectSample(.heartRate, start: .manual)
+                CollectSample(.heartRate, start: .manual)
                 
                 RequestReadAccess(
                     quantity: [.bloodOxygen],

--- a/Tests/UITests/TestAppUITests/SpeziHealthKitTests.swift
+++ b/Tests/UITests/TestAppUITests/SpeziHealthKitTests.swift
@@ -83,6 +83,9 @@ final class HealthKitTests: XCTestCase {
             .activeEnergyBurned: 3,
             .stepCount: 1
         ])
+        
+        app.buttons["Register additional CollectSample instances"].tap()
+        sleep(1) // give it some time to handle this.
     }
     
     


### PR DESCRIPTION
# Deferred Sample Collection; Improved Handling of Duplicate/Overlapping `CollectSample` Definitions

## :recycle: Current situation & Problem
- SpeziHealthKit currently requires all `CollectSample` definitions be defined as part of the module's initialization, which is too limiting for e.g. applications which don't statically know all sample types they want to collect.
- SpeziHealthKit currently doesn't handle duplicate `CollectSample` entries, and will as a result deliver the same new HealthKit sample multiple times to the standard.

This PR addresses and fixes both of these issues

(See #32 for more detail)

fixes #32 


## :gear: Release Notes 
- Allow registering `CollectSample` definitions after module initialization
- Properly handle (and merge/replace) duplicate/overlapping `CollectSample` definitions


## :books: Documentation
missing; will be added before merging


## :white_check_mark: Testing
missing; will be added before merging


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
