### PR TITLE
`SampleType.workout`

### DIFF
--- a/Sources/SpeziHealthKit/Configuration/HealthKitConfiguration.swift
+++ b/Sources/SpeziHealthKit/Configuration/HealthKitConfiguration.swift
@@ -28,7 +28,7 @@ public protocol HealthKitConfigurationComponent {
 
 extension HealthKit {
     /// Defines the object and sample types the ``HealthKit-swift.class`` module requires read and/or write access to.
-    public struct DataAccessRequirements {
+    public struct DataAccessRequirements: Hashable, Sendable {
         /// The object types a component needs read access to.
         /// The ``HealthKit-swift.class`` module will include these object types in the
         /// request when the app calls ``HealthKit-swift.class/askForAuthorization()``

--- a/Sources/SpeziHealthKit/Configuration/RequestReadAccess.swift
+++ b/Sources/SpeziHealthKit/Configuration/RequestReadAccess.swift
@@ -24,6 +24,7 @@ public struct RequestReadAccess: HealthKitConfigurationComponent {
     /// - parameter quantity: Any quantity sample types you wish to request read access for
     /// - parameter category: Any category sample types you wish to request read access for
     /// - parameter correlation: Any correlation sample types you wish to request read access for. Note: rather than requesting access for the correlation type itself (which is not allowed), this will request access for the set of the specific correlation types' underlying sample types. For example, a read access request to the ``SampleType/bloodPressure`` correlation type, will get translated into read access requests to ``SampleType/bloodPressureSystolic`` and ``SampleType/bloodPressureDiastolic``.
+    /// - parameter characteristic: Any characteristic sample types you wish to request read access for
     /// - parameter other: Any other sample types you wish to request read access to. Use this parameter for "special" sample types which don't fall into any of the other categories, e.g. ``SampleType/workout`` or ``SampleType/electrocardiogram``.
     public init(
         quantity: Set<SampleType<HKQuantitySample>> = [],

--- a/Sources/SpeziHealthKit/Configuration/RequestReadAccess.swift
+++ b/Sources/SpeziHealthKit/Configuration/RequestReadAccess.swift
@@ -21,16 +21,22 @@ public struct RequestReadAccess: HealthKitConfigurationComponent {
     }
     
     /// Creates a HealthKit configuration component that requests read access to the specified sample types.
+    /// - parameter quantity: Any quantity sample types you wish to request read access for
+    /// - parameter category: Any category sample types you wish to request read access for
+    /// - parameter correlation: Any correlation sample types you wish to request read access for. Note: rather than requesting access for the correlation type itself (which is not allowed), this will request access for the set of the specific correlation types' underlying sample types. For example, a read access request to the ``SampleType/bloodPressure`` correlation type, will get translated into read access requests to ``SampleType/bloodPressureSystolic`` and ``SampleType/bloodPressureDiastolic``.
+    /// - parameter other: Any other sample types you wish to request read access to. Use this parameter for "special" sample types which don't fall into any of the other categories, e.g. ``SampleType/workout`` or ``SampleType/electrocardiogram``.
     public init(
         quantity: Set<SampleType<HKQuantitySample>> = [],
         category: Set<SampleType<HKCategorySample>> = [],
         correlation: Set<SampleType<HKCorrelation>> = [],
-        characteristic: [any HealthKitCharacteristicProtocol] = []
+        characteristic: [any HealthKitCharacteristicProtocol] = [],
+        other: [any AnySampleType] = []
     ) {
         let types = Set<HKObjectType>(quantity.map(\.hkSampleType))
             .union(category.map(\.hkSampleType))
             .union(correlation.flatMap(\.associatedQuantityTypes).map(\.hkSampleType))
             .union(characteristic.map(\.hkType))
+            .union(other.map { $0.hkSampleType })
         self.init(types)
     }
     

--- a/Sources/SpeziHealthKit/Configuration/RequestReadAccess.swift
+++ b/Sources/SpeziHealthKit/Configuration/RequestReadAccess.swift
@@ -33,9 +33,7 @@ public struct RequestReadAccess: HealthKitConfigurationComponent {
         characteristic: [any HealthKitCharacteristicProtocol] = [],
         other: [any AnySampleType] = []
     ) {
-        let types = Set<HKObjectType>(quantity.map(\.hkSampleType))
-            .union(category.map(\.hkSampleType))
-            .union(correlation.flatMap(\.associatedQuantityTypes).map(\.hkSampleType))
+        let types = (collectAllUnderyingEffectiveSampleTypes(quantity, category, correlation) as Set<HKObjectType>)
             .union(characteristic.map(\.hkType))
             .union(other.map { $0.hkSampleType })
         self.init(types)

--- a/Sources/SpeziHealthKit/Configuration/RequestWriteAccess.swift
+++ b/Sources/SpeziHealthKit/Configuration/RequestWriteAccess.swift
@@ -21,14 +21,20 @@ public struct RequestWriteAccess: HealthKitConfigurationComponent {
     }
     
     /// Creates a HealthKit configuration component that requests write access to the specified type identifiers.
+    /// - parameter quantity: Any quantity sample types you wish to request write access for
+    /// - parameter category: Any category sample types you wish to request write access for
+    /// - parameter correlation: Any correlation sample types you wish to request write access for. Note: rather than requesting access for the correlation type itself (which is not allowed), this will request access for the set of the specific correlation types' underlying sample types. For example, a write access request to the ``SampleType/bloodPressure`` correlation type, will get translated into write access requests to ``SampleType/bloodPressureSystolic`` and ``SampleType/bloodPressureDiastolic``.
+    /// - parameter other: Any other sample types you wish to request write access to. Use this parameter for "special" sample types which don't fall into any of the other categories, e.g. ``SampleType/workout`` or ``SampleType/electrocardiogram``.
     public init(
         quantity: Set<SampleType<HKQuantitySample>> = [],
         category: Set<SampleType<HKCategorySample>> = [],
-        correlation: Set<SampleType<HKCorrelation>> = []
+        correlation: Set<SampleType<HKCorrelation>> = [],
+        other: [any AnySampleType] = []
     ) {
         let types = Set<HKSampleType>(quantity.map(\.hkSampleType))
             .union(category.map(\.hkSampleType))
             .union(correlation.flatMap(\.associatedQuantityTypes).map(\.hkSampleType))
+            .union(other.map { $0.hkSampleType })
         self.init(types)
     }
     

--- a/Sources/SpeziHealthKit/Configuration/RequestWriteAccess.swift
+++ b/Sources/SpeziHealthKit/Configuration/RequestWriteAccess.swift
@@ -31,9 +31,7 @@ public struct RequestWriteAccess: HealthKitConfigurationComponent {
         correlation: Set<SampleType<HKCorrelation>> = [],
         other: [any AnySampleType] = []
     ) {
-        let types = Set<HKSampleType>(quantity.map(\.hkSampleType))
-            .union(category.map(\.hkSampleType))
-            .union(correlation.flatMap(\.associatedQuantityTypes).map(\.hkSampleType))
+        let types = collectAllUnderyingEffectiveSampleTypes(quantity, category, correlation)
             .union(other.map { $0.hkSampleType })
         self.init(types)
     }

--- a/Sources/SpeziHealthKit/Health Data Collection/HealthDataCollector.swift
+++ b/Sources/SpeziHealthKit/Health Data Collection/HealthDataCollector.swift
@@ -17,7 +17,7 @@ import SwiftUI
 ///     In most cases, it shouldn't be necessary to define and implement a custom data collector.
 ///
 /// Custom `HealthDataCollector`s can be registered with the ``HealthKit-swift.class`` module
-/// using ``HealthKit-swift.class/addHealthDataCollector(_:)``.
+/// using ``HealthKit-swift.class/addHealthDataCollector(_:)-1sq79`` or ``HealthKit-swift.class/addHealthDataCollector(_:)-10bp6``.
 /// The ``HealthKit-swift.class`` module will establish a strong reference to the collector,
 /// which will exist for the entire lifetime of the application.
 public protocol HealthDataCollector: AnyObject {

--- a/Sources/SpeziHealthKit/HealthKit.swift
+++ b/Sources/SpeziHealthKit/HealthKit.swift
@@ -48,7 +48,8 @@ public final class HealthKit: Module, EnvironmentAccessible, DefaultInitializabl
     public let _initialConfigDataAccessRequirements: DataAccessRequirements // swiftlint:disable:this identifier_name
     
     /// Which HealthKit data we need to be able to access, for read and/or write operations.
-    private(set) var dataAccessRequirements: DataAccessRequirements
+    @MainActor
+    private(set) var dataAccessRequirements: DataAccessRequirements = .init()
     
     /// Whether all of the module's current data access requirements were prompted to the user.
     ///
@@ -56,24 +57,25 @@ public final class HealthKit: Module, EnvironmentAccessible, DefaultInitializabl
     /// e.g. if additional data access requirements are introduced after a call to ``HealthKit-swift.class/askForAuthorization()``, it might transition from `true` back to `false`.
     ///
     /// - Note: This property being `true` does not imply that the user actually granted access to all sample types; it just means that the user was asked.
+    @MainActor
     public private(set) var isFullyAuthorized: Bool = false
     
     /// The state of the module's configuration, i.e. whether the initial configuration is still pending, currently ongoing, or already completed.
-    @ObservationIgnored public private(set) var configurationState: ConfigState = .pending
+    @ObservationIgnored @MainActor public private(set) var configurationState: ConfigState = .pending
     
     /// Configurations which were supplied to the initializer, but have not yet been applied.
     /// - Note: This property is intended only to store the configuration until `configure()` has been called. It is not used afterwards.
-    @ObservationIgnored private var pendingConfiguration: [any HealthKitConfigurationComponent]
+    @ObservationIgnored @MainActor private var pendingConfiguration: [any HealthKitConfigurationComponent] = []
     
     /// All background-data-collecting data sources registered with the HealthKit module.
-    @ObservationIgnored /* private-but-testable */ private(set) var registeredDataCollectors: [any HealthDataCollector] = []
+    @ObservationIgnored @MainActor /* private-but-testable */ private(set) var registeredDataCollectors: [any HealthDataCollector] = []
     
     
     /// Creates a new instance of the ``HealthKit-class`` module, with the specified configuration.
     /// - parameter config: The configuration defines the behaviour of the `HealthKit` module,
     ///     specifying e.g. which samples the app wants to continuously collect (via ``CollectSample``),
     ///     and which sample and object types the user should be prompted to grant the app read access to (via ``RequestReadAccess``).
-    public init(
+    @MainActor public init(
         @ArrayBuilder<any HealthKitConfigurationComponent> _ config: () -> [any HealthKitConfigurationComponent]
     ) {
         healthStore = HKHealthStore()
@@ -82,6 +84,19 @@ public final class HealthKit: Module, EnvironmentAccessible, DefaultInitializabl
             dataReqs.merging(with: component.dataAccessRequirements)
         }
         dataAccessRequirements = _initialConfigDataAccessRequirements
+        checkHealthKitAvailability()
+    }
+    
+    
+    /// Creates a new instance of the ``HealthKit-class`` module, with an empty configuration.
+    public init() {
+        healthStore = HKHealthStore()
+        _initialConfigDataAccessRequirements = .init()
+        checkHealthKitAvailability()
+    }
+    
+    
+    private func checkHealthKitAvailability() {
         if !HKHealthStore.isHealthDataAvailable() {
             // If HealthKit is not available, we still initialise the module and the health store as normal.
             // Queries and sample collection, in this case, will simply not return any results.
@@ -92,12 +107,6 @@ public final class HealthKit: Module, EnvironmentAccessible, DefaultInitializabl
                 """
             )
         }
-    }
-    
-    
-    /// Creates a new instance of the ``HealthKit-class`` module, with an empty configuration.
-    public convenience init() {
-        self.init { /* intentionally empty config */ }
     }
     
     

--- a/Sources/SpeziHealthKit/HealthKit.swift
+++ b/Sources/SpeziHealthKit/HealthKit.swift
@@ -14,13 +14,6 @@ import SpeziLocalStorage
 import SwiftUI
 
 
-private func tmp_printToStderr(_ items: Any..., terminator: String = "\n") {
-    let text = "warning: " + items.map { String(describing: $0) }.joined(separator: " ") + terminator
-    fputs(text, stderr)
-    fflush(stderr)
-}
-
-
 /// Spezi Module for interacting with the HealthKit system.
 ///
 /// See <doc:ModuleConfiguration> for a detailed introduction.
@@ -112,13 +105,9 @@ public final class HealthKit: Module, EnvironmentAccessible, DefaultInitializabl
     @_documentation(visibility: internal)
     public func configure() {
         configurationState = .ongoing
-        tmp_printToStderr("HealthKit.configure/0")
         Task {
-            tmp_printToStderr("HealthKit.configure/1")
             for (idx, component) in exchange(&pendingConfiguration, with: []).enumerated() {
-                tmp_printToStderr("HealthKit.configure idx=\(idx) START")
                 await component.configure(for: self, on: self.standard)
-                tmp_printToStderr("HealthKit.configure idx=\(idx) END")
             }
             configurationState = .completed
         }

--- a/Sources/SpeziHealthKit/HealthKit.swift
+++ b/Sources/SpeziHealthKit/HealthKit.swift
@@ -95,9 +95,12 @@ public final class HealthKit: Module, EnvironmentAccessible, DefaultInitializabl
     @_documentation(visibility: internal)
     public func configure() {
         Task {
+            fputs("HealthKit.configure\n", stderr)
             didConfigure = true
-            for component in exchange(&pendingConfiguration, with: []) {
+            for (idx, component) in exchange(&pendingConfiguration, with: []).enumerated() {
+                fputs("HealthKit.configure idx=\(idx) START\n", stderr)
                 await component.configure(for: self, on: self.standard)
+                fputs("HealthKit.configure idx=\(idx) END\n", stderr)
             }
         }
     }

--- a/Sources/SpeziHealthKit/HealthKit.swift
+++ b/Sources/SpeziHealthKit/HealthKit.swift
@@ -14,6 +14,13 @@ import SpeziLocalStorage
 import SwiftUI
 
 
+private func tmp_printToStderr(_ items: Any..., terminator: String = "\n") {
+    let text = items.map { String(describing: $0) }.joined(separator: " ") + terminator
+    fputs(text, stderr)
+    fflush(stderr)
+}
+
+
 /// Spezi Module for interacting with the HealthKit system.
 ///
 /// See <doc:ModuleConfiguration> for a detailed introduction.
@@ -95,12 +102,12 @@ public final class HealthKit: Module, EnvironmentAccessible, DefaultInitializabl
     @_documentation(visibility: internal)
     public func configure() {
         Task {
-            fputs("HealthKit.configure\n", stderr)
+            tmp_printToStderr("HealthKit.configure")
             didConfigure = true
             for (idx, component) in exchange(&pendingConfiguration, with: []).enumerated() {
-                fputs("HealthKit.configure idx=\(idx) START\n", stderr)
+                tmp_printToStderr("HealthKit.configure idx=\(idx) START")
                 await component.configure(for: self, on: self.standard)
-                fputs("HealthKit.configure idx=\(idx) END\n", stderr)
+                tmp_printToStderr("HealthKit.configure idx=\(idx) END")
             }
         }
     }

--- a/Sources/SpeziHealthKit/HealthKit.swift
+++ b/Sources/SpeziHealthKit/HealthKit.swift
@@ -314,9 +314,9 @@ extension HealthKit {
         case .dontAdd:
             return
         case .replace(let index):
-            await registeredDataCollectors[index].stopDataCollection()
-            registeredDataCollectors.remove(at: index)
-            fallthrough
+            let oldCollector = exchange(&registeredDataCollectors[index], with: newCollector)
+            await oldCollector.stopDataCollection()
+            await startAutomaticDataCollectionIfPossible(newCollector)
         case .add:
             registeredDataCollectors.append(newCollector)
             await startAutomaticDataCollectionIfPossible(newCollector)

--- a/Sources/SpeziHealthKit/HealthKit.swift
+++ b/Sources/SpeziHealthKit/HealthKit.swift
@@ -15,7 +15,7 @@ import SwiftUI
 
 
 private func tmp_printToStderr(_ items: Any..., terminator: String = "\n") {
-    let text = items.map { String(describing: $0) }.joined(separator: " ") + terminator
+    let text = "warning: " + items.map { String(describing: $0) }.joined(separator: " ") + terminator
     fputs(text, stderr)
     fflush(stderr)
 }
@@ -101,8 +101,9 @@ public final class HealthKit: Module, EnvironmentAccessible, DefaultInitializabl
     /// Configures the HealthKit module.
     @_documentation(visibility: internal)
     public func configure() {
+        tmp_printToStderr("HealthKit.configure/0")
         Task {
-            tmp_printToStderr("HealthKit.configure")
+            tmp_printToStderr("HealthKit.configure/1")
             didConfigure = true
             for (idx, component) in exchange(&pendingConfiguration, with: []).enumerated() {
                 tmp_printToStderr("HealthKit.configure idx=\(idx) START")

--- a/Sources/SpeziHealthKit/Resources/Localizable.xcstrings
+++ b/Sources/SpeziHealthKit/Resources/Localizable.xcstrings
@@ -480,6 +480,9 @@
         }
       }
     },
+    "Workout" : {
+
+    },
     "Wrist Temperature" : {
 
     },

--- a/Sources/SpeziHealthKit/Sample Types/SampleType.swift
+++ b/Sources/SpeziHealthKit/Sample Types/SampleType.swift
@@ -21,7 +21,7 @@ public struct SampleType<Sample: _HKSampleWithSampleType>: AnySampleType {
         case correlation(associatedQuantityTypes: Set<SampleType<HKQuantitySample>>)
         case category
         /// The ``SampleType`` represents an `HKSampleType` outside the "normal" ones, i.e. one that isn't a quantity, correlation, or category sample,
-        /// and which we also don't need to carrt any special data for.
+        /// and which we also don't need to carry any special data for.
         case other
     }
     
@@ -119,7 +119,6 @@ extension SampleType {
     /// Use this initializer only if the sample type you want to work with isn't already defined by SpeziHealthKit.
     /// - parameter identifier: The sample type's underlying `HKCorrelationTypeIdentifier`
     /// - parameter displayTitle: The localized string which should be used when displaying this sample type's title in a user-visible context.
-    /// - parameter displayUnit: The unit which should be used when displaying values of this correlation type to the user, if applicable.
     @inlinable public static func correlation(
         _ identifier: HKCorrelationTypeIdentifier,
         displayTitle: LocalizedStringResource,

--- a/Sources/SpeziHealthKit/Sample Types/SampleType.swift
+++ b/Sources/SpeziHealthKit/Sample Types/SampleType.swift
@@ -20,8 +20,9 @@ public struct SampleType<Sample: _HKSampleWithSampleType>: AnySampleType {
         /// - parameter associatedQuantityTypes: The correlation's associated sample types, if known.
         case correlation(associatedQuantityTypes: Set<SampleType<HKQuantitySample>>)
         case category
-        case electrocardiogram
-        case audiogram
+        /// The ``SampleType`` represents an `HKSampleType` outside the "normal" ones, i.e. one that isn't a quantity, correlation, or category sample,
+        /// and which we also don't need to carrt any special data for.
+        case other
     }
     
     public let hkSampleType: Sample._SampleType
@@ -50,7 +51,7 @@ extension SampleType where Sample == HKQuantitySample {
         switch variant {
         case .quantity(let displayUnit, _):
             return displayUnit
-        case .correlation, .category, .electrocardiogram, .audiogram:
+        case .correlation, .category, .other:
             // SAFETY:
             // This branch is unreachable; the initializers are defined and structured in a way that all
             // `SampleType<HKQuantitySample>` objects always must specify a displayUnit.
@@ -65,7 +66,7 @@ extension SampleType where Sample == HKQuantitySample {
         switch variant {
         case .quantity(displayUnit: _, let expectedValuesRange):
             return expectedValuesRange
-        case .correlation, .category, .electrocardiogram, .audiogram:
+        case .correlation, .category, .other:
             // SAFETY:
             // This branch is unreachable; the initializers are defined and structured in a way that all
             // `SampleType<HKQuantitySample>` objects always must specify an expectedValuesRange.
@@ -81,7 +82,7 @@ extension SampleType where Sample == HKCorrelation {
         switch variant {
         case .correlation(let associatedQuantityTypes):
             return associatedQuantityTypes
-        case .quantity, .category, .electrocardiogram, .audiogram:
+        case .quantity, .category, .other:
             // SAFETY:
             // This branch is unreachable; the initializers are defined and structured in a way that all
             // `SampleType<HKCorrelation>` objects always must specify associatedQuantityTypes.
@@ -142,17 +143,25 @@ extension SampleType {
 
 // MARK: Other sample types
 
-extension SampleType {
+extension SampleType where Sample == HKElectrocardiogram {
     /// The electrocardiogram sample type
     @inlinable public static var electrocardiogram: SampleType<HKElectrocardiogram> {
-        .init(HKSampleType.electrocardiogramType(), displayTitle: "ECG", variant: .electrocardiogram)
+        .init(HKSampleType.electrocardiogramType(), displayTitle: "ECG", variant: .other)
     }
 }
 
 
-extension SampleType {
+extension SampleType where Sample == HKAudiogramSample {
     /// The audiogram sample type
     @inlinable public static var audiogram: SampleType<HKAudiogramSample> {
-        .init(HKSampleType.audiogramSampleType(), displayTitle: "Audiogram", variant: .audiogram)
+        .init(HKSampleType.audiogramSampleType(), displayTitle: "Audiogram", variant: .other)
+    }
+}
+
+
+extension SampleType where Sample == HKWorkout {
+    /// The workout sample type
+    @inlinable public static var workout: SampleType<HKWorkout> {
+        .init(HKSampleType.workoutType(), displayTitle: "Workout", variant: .other)
     }
 }

--- a/Sources/SpeziHealthKit/Sample Types/_HKSampleWithSampleType.swift
+++ b/Sources/SpeziHealthKit/Sample Types/_HKSampleWithSampleType.swift
@@ -37,4 +37,8 @@ extension HKAudiogramSample: _HKSampleWithSampleType {
     public typealias _SampleType = HKAudiogramSampleType
 }
 
+extension HKWorkout: _HKSampleWithSampleType {
+    public typealias _SampleType = HKWorkoutType
+}
+
 // swiftlint:enable type_name

--- a/Sources/SpeziHealthKit/SpeziHealthKit.docc/SampleType.md
+++ b/Sources/SpeziHealthKit/SpeziHealthKit.docc/SampleType.md
@@ -26,7 +26,6 @@ For example, the sample type representing heart rate samples (``SampleType/heart
 - ``SampleType/hkSampleType``
 - ``SampleType/displayTitle``
 - ``SampleType/displayUnit-1rnhb``
-- ``SampleType/displayUnit-4gadf``
 - ``SampleType/expectedValuesRange``
 
 ### Well-known quantity types
@@ -45,7 +44,7 @@ For example, the sample type representing heart rate samples (``SampleType/heart
 
 ### Creating new SampleTypes
 - ``SampleType/quantity(_:displayTitle:displayUnit:expectedValuesRange:)``
-- ``SampleType/correlation(_:displayTitle:displayUnit:)``
+- ``SampleType/correlation(_:displayTitle:associatedQuantityTypes:)``
 - ``SampleType/category(_:displayTitle:)``
 
 

--- a/Sources/SpeziHealthKitUI/Queries/HealthKitQueryTimeRange.swift
+++ b/Sources/SpeziHealthKitUI/Queries/HealthKitQueryTimeRange.swift
@@ -80,6 +80,11 @@ extension HealthKitQueryTimeRange {
         .init(Calendar.current.rangeOfYear(for: .now))
     }
     
+    /// The time range encompassing all of time.
+    public static var ever: Self {
+        .init(Date.distantPast..<Date.distantFuture)
+    }
+    
     /// The time range encompassing the last `N` hours, starting at the end of the current hour.
     public static func last(hours: Int) -> Self {
         lastXImp(.hour, startOfComponentFn: Calendar.startOfHour, numUnits: hours)

--- a/Sources/SpeziHealthKitUI/SpeziHealthKitUI.docc/SpeziHealthKitUI.md
+++ b/Sources/SpeziHealthKitUI/SpeziHealthKitUI.docc/SpeziHealthKitUI.md
@@ -25,7 +25,6 @@ Use SpeziHealthKitUI's ``HealthChart`` to visualize health data queried via [`Sp
 - ``HealthKitQueryTimeRange``
 - ``HealthKitQueryResults``
 - ``HealthKitCharacteristicQuery``
-- ``HealthKitCharacteristic``
 
 ### Visualizing Queried Health Data
 - ``HealthChart``

--- a/Tests/SpeziHealthKitTests/HealthDataCollectorRegistrationTests.swift
+++ b/Tests/SpeziHealthKitTests/HealthDataCollectorRegistrationTests.swift
@@ -39,9 +39,10 @@ final class HealthDataCollectorRegistrationTests: XCTestCase {
             healthKit
         }
         
+        try await Task.sleep(for: .seconds(10))
+        
         var erasedCollectors: [AnyObject] = healthKit.registeredDataCollectors
         
-        try await Task.sleep(for: .seconds(1))
         XCTAssertEqual(healthKit.registeredDataCollectors.count, 2)
         XCTAssertEqual(Set(healthKit.registeredDataCollectors.map { $0.typeErasedSampleType.displayTitle }), [SampleType.heartRate, .stepCount, .bloodOxygen, .height, .bodyMass].mapIntoSet(\.displayTitle))
         XCTAssertEqual(1, healthKit.registeredDataCollectors.count { $0.typeErasedSampleType == .heartRate })

--- a/Tests/SpeziHealthKitTests/HealthDataCollectorRegistrationTests.swift
+++ b/Tests/SpeziHealthKitTests/HealthDataCollectorRegistrationTests.swift
@@ -20,31 +20,36 @@ private actor TestStandard: Standard, HealthKitConstraint {
 
 
 final class HealthDataCollectorRegistrationTests: XCTestCase {
-    @MainActor
+//    @MainActor
     func testCollectSamplesRegistration() async throws {
         let healthKit = HealthKit {
-            CollectSample(.stepCount, continueInBackground: false)
+//            CollectSample(.stepCount, continueInBackground: false)
             CollectSample(.heartRate)
             CollectSample(.heartRate)
             CollectSample(.stepCount, continueInBackground: false)
             CollectSample(.stepCount, continueInBackground: true)
-            CollectSample(.bloodOxygen, continueInBackground: false)
-            CollectSample(.bloodOxygen, continueInBackground: true)
-            CollectSample(.height, continueInBackground: true)
-            CollectSample(.height, continueInBackground: false)
-            CollectSample(.bodyMass)
-            CollectSample(.bodyMass)
+//            CollectSample(.bloodOxygen, continueInBackground: false)
+//            CollectSample(.bloodOxygen, continueInBackground: true)
+//            CollectSample(.height, continueInBackground: true)
+//            CollectSample(.height, continueInBackground: false)
+//            CollectSample(.bodyMass)
+//            CollectSample(.bodyMass)
         }
-        withDependencyResolution(standard: TestStandard()) {
+        await withDependencyResolution(standard: TestStandard()) {
             healthKit
         }
         
-        try await Task.sleep(for: .seconds(10))
+        while healthKit.configurationState != .completed {
+            try await Task.sleep(for: .seconds(1))
+        }
+        
+//        try await Task.sleep(for: .seconds(10))
         
         var erasedCollectors: [AnyObject] = healthKit.registeredDataCollectors
         
         XCTAssertEqual(healthKit.registeredDataCollectors.count, 2)
-        XCTAssertEqual(Set(healthKit.registeredDataCollectors.map { $0.typeErasedSampleType.displayTitle }), [SampleType.heartRate, .stepCount, .bloodOxygen, .height, .bodyMass].mapIntoSet(\.displayTitle))
+//        XCTAssertEqual(Set(healthKit.registeredDataCollectors.map { $0.typeErasedSampleType.displayTitle }), [SampleType.heartRate, .stepCount, .bloodOxygen, .height, .bodyMass].mapIntoSet(\.displayTitle))
+        XCTAssertEqual(Set(healthKit.registeredDataCollectors.map { $0.typeErasedSampleType.displayTitle }), [SampleType.heartRate, .stepCount].mapIntoSet(\.displayTitle))
         XCTAssertEqual(1, healthKit.registeredDataCollectors.count { $0.typeErasedSampleType == .heartRate })
         XCTAssertEqual(1, healthKit.registeredDataCollectors.count { $0.typeErasedSampleType == .stepCount })
         

--- a/Tests/SpeziHealthKitTests/HealthDataCollectorRegistrationTests.swift
+++ b/Tests/SpeziHealthKitTests/HealthDataCollectorRegistrationTests.swift
@@ -40,7 +40,7 @@ final class HealthDataCollectorRegistrationTests: XCTestCase {
         
         try await Task.sleep(for: .seconds(1))
         XCTAssertEqual(healthKit.registeredDataCollectors.count, 2)
-        XCTAssertEqual(Set(healthKit.registeredDataCollectors.map { $0.typeErasedSampleType.displayTitle }), ["Heart Rate", "Step Count"])
+        XCTAssertEqual(Set(healthKit.registeredDataCollectors.map { $0.typeErasedSampleType.displayTitle }), [SampleType.heartRate, .stepCount, .bloodOxygen, .height].mapIntoSet(\.displayTitle))
         XCTAssertEqual(1, healthKit.registeredDataCollectors.count { $0.typeErasedSampleType == .heartRate })
         XCTAssertEqual(1, healthKit.registeredDataCollectors.count { $0.typeErasedSampleType == .stepCount })
         

--- a/Tests/SpeziHealthKitTests/HealthDataCollectorRegistrationTests.swift
+++ b/Tests/SpeziHealthKitTests/HealthDataCollectorRegistrationTests.swift
@@ -36,7 +36,9 @@ final class HealthDataCollectorRegistrationTests: XCTestCase {
         
         try await Task.sleep(for: .seconds(1))
         XCTAssertEqual(healthKit.registeredDataCollectors.count, 2)
+        XCTAssertEqual(Set(healthKit.registeredDataCollectors.map { $0.typeErasedSampleType.displayTitle }), ["Heart Rate", "Step Count"])
         XCTAssertEqual(1, healthKit.registeredDataCollectors.count { $0.typeErasedSampleType == .heartRate })
+        XCTAssertEqual(1, healthKit.registeredDataCollectors.count { $0.typeErasedSampleType == .stepCount })
         
         await healthKit.addHealthDataCollector(CollectSample(.bloodOxygen))
         XCTAssertEqual(healthKit.registeredDataCollectors.count, 3)

--- a/Tests/SpeziHealthKitTests/HealthDataCollectorRegistrationTests.swift
+++ b/Tests/SpeziHealthKitTests/HealthDataCollectorRegistrationTests.swift
@@ -20,20 +20,19 @@ private actor TestStandard: Standard, HealthKitConstraint {
 
 
 final class HealthDataCollectorRegistrationTests: XCTestCase {
-//    @MainActor
     func testCollectSamplesRegistration() async throws {
         let healthKit = HealthKit {
-//            CollectSample(.stepCount, continueInBackground: false)
+            CollectSample(.stepCount, continueInBackground: false)
             CollectSample(.heartRate)
             CollectSample(.heartRate)
             CollectSample(.stepCount, continueInBackground: false)
             CollectSample(.stepCount, continueInBackground: true)
-//            CollectSample(.bloodOxygen, continueInBackground: false)
-//            CollectSample(.bloodOxygen, continueInBackground: true)
-//            CollectSample(.height, continueInBackground: true)
-//            CollectSample(.height, continueInBackground: false)
-//            CollectSample(.bodyMass)
-//            CollectSample(.bodyMass)
+            CollectSample(.bloodGlucose, continueInBackground: false)
+            CollectSample(.bloodGlucose, continueInBackground: true)
+            CollectSample(.dietaryPotassium, continueInBackground: true)
+            CollectSample(.dietaryPotassium, continueInBackground: false)
+            CollectSample(.pushCount)
+            CollectSample(.pushCount)
         }
         await withDependencyResolution(standard: TestStandard()) {
             healthKit
@@ -43,43 +42,38 @@ final class HealthDataCollectorRegistrationTests: XCTestCase {
             try await Task.sleep(for: .seconds(1))
         }
         
-//        try await Task.sleep(for: .seconds(10))
-        
         var erasedCollectors: [AnyObject] = healthKit.registeredDataCollectors
         
-        XCTAssertEqual(healthKit.registeredDataCollectors.count, 2)
-//        XCTAssertEqual(Set(healthKit.registeredDataCollectors.map { $0.typeErasedSampleType.displayTitle }), [SampleType.heartRate, .stepCount, .bloodOxygen, .height, .bodyMass].mapIntoSet(\.displayTitle))
-        XCTAssertEqual(Set(healthKit.registeredDataCollectors.map { $0.typeErasedSampleType.displayTitle }), [SampleType.heartRate, .stepCount].mapIntoSet(\.displayTitle))
-        XCTAssertEqual(1, healthKit.registeredDataCollectors.count { $0.typeErasedSampleType == .heartRate })
-        XCTAssertEqual(1, healthKit.registeredDataCollectors.count { $0.typeErasedSampleType == .stepCount })
+        XCTAssertEqual(healthKit.registeredDataCollectors.count, 5)
+        XCTAssertEqual(Set(healthKit.registeredDataCollectors.map { $0.typeErasedSampleType.displayTitle }), [SampleType.heartRate, .stepCount, .bloodGlucose, .dietaryPotassium, .pushCount].mapIntoSet(\.displayTitle))
         
         await healthKit.addHealthDataCollector(CollectSample(.bloodOxygen))
-        XCTAssertEqual(healthKit.registeredDataCollectors.count, 3)
+        XCTAssertEqual(healthKit.registeredDataCollectors.count, 6)
         
         erasedCollectors = healthKit.registeredDataCollectors
         await healthKit.addHealthDataCollector(CollectSample(.bloodOxygen))
         XCTAssert(erasedCollectors.elementsEqual(healthKit.registeredDataCollectors, by: ===))
-        XCTAssertEqual(healthKit.registeredDataCollectors.count, 3)
+        XCTAssertEqual(healthKit.registeredDataCollectors.count, 6)
         
         await healthKit.addHealthDataCollector(CollectSample(.walkingStepLength, continueInBackground: true))
-        XCTAssertEqual(healthKit.registeredDataCollectors.count, 4)
+        XCTAssertEqual(healthKit.registeredDataCollectors.count, 7)
         erasedCollectors = healthKit.registeredDataCollectors
         await healthKit.addHealthDataCollector(CollectSample(.walkingStepLength, continueInBackground: true))
         // nothing should change, since the new collector is equal to an existing one.
-        XCTAssertEqual(healthKit.registeredDataCollectors.count, 4)
+        XCTAssertEqual(healthKit.registeredDataCollectors.count, 7)
         XCTAssert(erasedCollectors.elementsEqual(healthKit.registeredDataCollectors, by: ===))
         await healthKit.addHealthDataCollector(CollectSample(.walkingStepLength, continueInBackground: false))
         // nothing should change, since the new (non-bg) collector will get subsumed into the existing (bg) one.
-        XCTAssertEqual(healthKit.registeredDataCollectors.count, 4)
+        XCTAssertEqual(healthKit.registeredDataCollectors.count, 7)
         XCTAssert(erasedCollectors.elementsEqual(healthKit.registeredDataCollectors, by: ===))
         
         await healthKit.addHealthDataCollector(CollectSample(.height, continueInBackground: false))
-        XCTAssertEqual(healthKit.registeredDataCollectors.count, 5)
+        XCTAssertEqual(healthKit.registeredDataCollectors.count, 8)
         erasedCollectors = healthKit.registeredDataCollectors
         await healthKit.addHealthDataCollector(CollectSample(.height, continueInBackground: true))
         // we expect the second height collector to replace the first (background vs non-background),
         // so the #collectors will remain the same, but they won't compare equal anymore
-        XCTAssertEqual(healthKit.registeredDataCollectors.count, 5)
+        XCTAssertEqual(healthKit.registeredDataCollectors.count, 8)
         XCTAssertFalse(erasedCollectors.elementsEqual(healthKit.registeredDataCollectors, by: ===))
     }
 }

--- a/Tests/SpeziHealthKitTests/HealthDataCollectorRegistrationTests.swift
+++ b/Tests/SpeziHealthKitTests/HealthDataCollectorRegistrationTests.swift
@@ -45,7 +45,10 @@ final class HealthDataCollectorRegistrationTests: XCTestCase {
         var erasedCollectors: [AnyObject] = healthKit.registeredDataCollectors
         
         XCTAssertEqual(healthKit.registeredDataCollectors.count, 5)
-        XCTAssertEqual(Set(healthKit.registeredDataCollectors.map { $0.typeErasedSampleType.displayTitle }), [SampleType.heartRate, .stepCount, .bloodGlucose, .dietaryPotassium, .pushCount].mapIntoSet(\.displayTitle))
+        XCTAssertEqual(
+            Set(healthKit.registeredDataCollectors.map { $0.typeErasedSampleType.displayTitle }),
+            [SampleType.heartRate, .stepCount, .bloodGlucose, .dietaryPotassium, .pushCount].mapIntoSet(\.displayTitle)
+        )
         
         await healthKit.addHealthDataCollector(CollectSample(.bloodOxygen))
         XCTAssertEqual(healthKit.registeredDataCollectors.count, 6)

--- a/Tests/SpeziHealthKitTests/HealthDataCollectorRegistrationTests.swift
+++ b/Tests/SpeziHealthKitTests/HealthDataCollectorRegistrationTests.swift
@@ -27,6 +27,10 @@ final class HealthDataCollectorRegistrationTests: XCTestCase {
             CollectSample(.heartRate)
             CollectSample(.stepCount, continueInBackground: false)
             CollectSample(.stepCount, continueInBackground: true)
+            CollectSample(.bloodOxygen, continueInBackground: false)
+            CollectSample(.bloodOxygen, continueInBackground: true)
+            CollectSample(.height, continueInBackground: true)
+            CollectSample(.height, continueInBackground: false)
         }
         withDependencyResolution(standard: TestStandard()) {
             healthKit

--- a/Tests/SpeziHealthKitTests/HealthDataCollectorRegistrationTests.swift
+++ b/Tests/SpeziHealthKitTests/HealthDataCollectorRegistrationTests.swift
@@ -31,6 +31,7 @@ final class HealthDataCollectorRegistrationTests: XCTestCase {
             CollectSample(.bloodOxygen, continueInBackground: true)
             CollectSample(.height, continueInBackground: true)
             CollectSample(.height, continueInBackground: false)
+            CollectSample(.weight)
         }
         withDependencyResolution(standard: TestStandard()) {
             healthKit
@@ -40,7 +41,7 @@ final class HealthDataCollectorRegistrationTests: XCTestCase {
         
         try await Task.sleep(for: .seconds(1))
         XCTAssertEqual(healthKit.registeredDataCollectors.count, 2)
-        XCTAssertEqual(Set(healthKit.registeredDataCollectors.map { $0.typeErasedSampleType.displayTitle }), [SampleType.heartRate, .stepCount, .bloodOxygen, .height].mapIntoSet(\.displayTitle))
+        XCTAssertEqual(Set(healthKit.registeredDataCollectors.map { $0.typeErasedSampleType.displayTitle }), [SampleType.heartRate, .stepCount, .bloodOxygen, .height, .weight].mapIntoSet(\.displayTitle))
         XCTAssertEqual(1, healthKit.registeredDataCollectors.count { $0.typeErasedSampleType == .heartRate })
         XCTAssertEqual(1, healthKit.registeredDataCollectors.count { $0.typeErasedSampleType == .stepCount })
         

--- a/Tests/SpeziHealthKitTests/HealthDataCollectorRegistrationTests.swift
+++ b/Tests/SpeziHealthKitTests/HealthDataCollectorRegistrationTests.swift
@@ -23,8 +23,9 @@ final class HealthDataCollectorRegistrationTests: XCTestCase {
     @MainActor
     func testCollectSamplesRegistration() async throws {
         let healthKit = HealthKit {
-//            CollectSample(.heartRate)
-//            CollectSample(.heartRate)
+            CollectSample(.stepCount, continueInBackground: false)
+            CollectSample(.heartRate)
+            CollectSample(.heartRate)
             CollectSample(.stepCount, continueInBackground: false)
             CollectSample(.stepCount, continueInBackground: true)
             CollectSample(.bloodOxygen, continueInBackground: false)

--- a/Tests/SpeziHealthKitTests/HealthDataCollectorRegistrationTests.swift
+++ b/Tests/SpeziHealthKitTests/HealthDataCollectorRegistrationTests.swift
@@ -23,14 +23,15 @@ final class HealthDataCollectorRegistrationTests: XCTestCase {
     @MainActor
     func testCollectSamplesRegistration() async throws {
         let healthKit = HealthKit {
-            CollectSample(.heartRate)
-            CollectSample(.heartRate)
+//            CollectSample(.heartRate)
+//            CollectSample(.heartRate)
             CollectSample(.stepCount, continueInBackground: false)
             CollectSample(.stepCount, continueInBackground: true)
             CollectSample(.bloodOxygen, continueInBackground: false)
             CollectSample(.bloodOxygen, continueInBackground: true)
             CollectSample(.height, continueInBackground: true)
             CollectSample(.height, continueInBackground: false)
+            CollectSample(.bodyMass)
             CollectSample(.bodyMass)
         }
         withDependencyResolution(standard: TestStandard()) {

--- a/Tests/SpeziHealthKitTests/HealthDataCollectorRegistrationTests.swift
+++ b/Tests/SpeziHealthKitTests/HealthDataCollectorRegistrationTests.swift
@@ -31,7 +31,7 @@ final class HealthDataCollectorRegistrationTests: XCTestCase {
             CollectSample(.bloodOxygen, continueInBackground: true)
             CollectSample(.height, continueInBackground: true)
             CollectSample(.height, continueInBackground: false)
-            CollectSample(.weight)
+            CollectSample(.bodyMass)
         }
         withDependencyResolution(standard: TestStandard()) {
             healthKit
@@ -41,7 +41,7 @@ final class HealthDataCollectorRegistrationTests: XCTestCase {
         
         try await Task.sleep(for: .seconds(1))
         XCTAssertEqual(healthKit.registeredDataCollectors.count, 2)
-        XCTAssertEqual(Set(healthKit.registeredDataCollectors.map { $0.typeErasedSampleType.displayTitle }), [SampleType.heartRate, .stepCount, .bloodOxygen, .height, .weight].mapIntoSet(\.displayTitle))
+        XCTAssertEqual(Set(healthKit.registeredDataCollectors.map { $0.typeErasedSampleType.displayTitle }), [SampleType.heartRate, .stepCount, .bloodOxygen, .height, .bodyMass].mapIntoSet(\.displayTitle))
         XCTAssertEqual(1, healthKit.registeredDataCollectors.count { $0.typeErasedSampleType == .heartRate })
         XCTAssertEqual(1, healthKit.registeredDataCollectors.count { $0.typeErasedSampleType == .stepCount })
         

--- a/Tests/UITests/TestApp/HealthKitTestsView/HealthKitTestsView.swift
+++ b/Tests/UITests/TestApp/HealthKitTestsView/HealthKitTestsView.swift
@@ -40,6 +40,7 @@ struct HealthKitTestsView: View {
                     await healthKit.addHealthDataCollector(CollectSample(.stairAscentSpeed, continueInBackground: false))
                     await healthKit.addHealthDataCollector(CollectSample(.stairDescentSpeed, continueInBackground: true))
                 }
+                LabeledContent("isFullyAuthorized", value: "\(healthKit.isFullyAuthorized)")
             }
             Section {
                 NavigationLink("Samples Query") {
@@ -114,10 +115,10 @@ struct HealthKitTestsView: View {
     private func checkInitialSamplesAuthStatus() async {
         let reqs = healthKit._initialConfigDataAccessRequirements
         let readFullyAuthd = await reqs.read.allSatisfy { @MainActor type in
-            await healthKit.askedForAuthorization(toRead: type)
+            await healthKit.didAskForAuthorization(toRead: type)
         }
         let writeFullyAuthd = reqs.write.allSatisfy { type in
-            healthKit.askedForAuthorization(toWrite: type)
+            healthKit.didAskForAuthorization(toWrite: type)
         }
         allInitialSampleTypesAreAuthorized = readFullyAuthd && writeFullyAuthd
     }

--- a/Tests/UITests/TestApp/TestAppDelegate.swift
+++ b/Tests/UITests/TestApp/TestAppDelegate.swift
@@ -36,11 +36,13 @@ class TestAppDelegate: SpeziAppDelegate {
                 
                 CollectSample(.stairAscentSpeed, continueInBackground: true)
                 CollectSample(.stairDescentSpeed, continueInBackground: false)
+                CollectSample(.workout)
                 
                 RequestReadAccess(
                     quantity: [.bloodOxygen],
                     correlation: [.bloodPressure],
-                    characteristic: [.activityMoveMode, .biologicalSex, .bloodType, .dateOfBirth, .fitzpatrickSkinType, .wheelchairUse]
+                    characteristic: [.activityMoveMode, .biologicalSex, .bloodType, .dateOfBirth, .fitzpatrickSkinType, .wheelchairUse],
+                    other: [SampleType.workout, SampleType.audiogram]
                 )
                 
                 RequestWriteAccess(

--- a/Tests/UITests/TestAppUITests/SpeziHealthKitTests.swift
+++ b/Tests/UITests/TestAppUITests/SpeziHealthKitTests.swift
@@ -201,7 +201,7 @@ extension HealthKitTests {
     @MainActor
     private func addSample(_ sampleType: SampleType<HKQuantitySample>, in app: XCUIApplication) throws {
         let menuButton = app.navigationBars.images["plus"]
-        XCTAssert(menuButton.wait(for: \.isEnabled, toEqual: true, timeout: 1))
+        XCTAssert(menuButton.waitForExistence(timeout: 1))
         menuButton.tap()
         let addSampleButton = app.buttons["Add Sample: \(sampleType.displayTitle)"]
         XCTAssert(addSampleButton.waitForExistence(timeout: 2))

--- a/Tests/UITests/TestAppUITests/SpeziHealthKitTests.swift
+++ b/Tests/UITests/TestAppUITests/SpeziHealthKitTests.swift
@@ -200,9 +200,13 @@ extension HealthKitTests {
     
     @MainActor
     private func addSample(_ sampleType: SampleType<HKQuantitySample>, in app: XCUIApplication) throws {
-        app.navigationBars.images["plus"].tap()
-        XCTAssert(app.buttons["Add Sample: \(sampleType.displayTitle)"].waitForExistence(timeout: 2))
-        app.buttons["Add Sample: \(sampleType.displayTitle)"].tap()
+        let menuButton = app.navigationBars.images["plus"]
+        XCTAssert(menuButton.wait(for: \.isEnabled, toEqual: true, timeout: 1))
+        menuButton.tap()
+        let addSampleButton = app.buttons["Add Sample: \(sampleType.displayTitle)"]
+        XCTAssert(addSampleButton.waitForExistence(timeout: 2))
+        addSampleButton.tap()
+        usleep(500_000) // i sleep
     }
     
     


### PR DESCRIPTION
# `SampleType.workout`

## :recycle: Current situation & Problem
- SpeziHealthKit's `SampleType` currently doesn't support workout samples.
- It's currently somewhat cumbersome to specify non-quantity/correlation/category sample types in some places (eg when requesting read/write access)


## :gear: Release Notes 
- Added `SampleType.workout`
- Added `other` parameters to the `RequestReadAccess` and `RequestWriteAccess` initializers


## :books: Documentation
The new sample type is documented

## :white_check_mark: Testing
n/a. this PR isn't adding or changing functionality.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
