### PR TITLE
fix isFullyAuthorized

### DIFF
--- a/Sources/SpeziHealthKit/HealthKit.swift
+++ b/Sources/SpeziHealthKit/HealthKit.swift
@@ -380,6 +380,7 @@ extension HealthKit {
             registeredDataCollectors.append(newCollector)
             await startAutomaticDataCollectionIfPossible(newCollector)
         }
+        await updateIsFullyAuthorized(for: dataAccessRequirements)
     }
     
     

--- a/Sources/SpeziHealthKit/HealthKit.swift
+++ b/Sources/SpeziHealthKit/HealthKit.swift
@@ -109,6 +109,7 @@ public final class HealthKit: Module, EnvironmentAccessible, DefaultInitializabl
             for component in exchange(&pendingConfiguration, with: []) {
                 await component.configure(for: self, on: self.standard)
             }
+            await updateIsFullyAuthorized(for: dataAccessRequirements)
             configurationState = .completed
         }
     }


### PR DESCRIPTION
# fix isFullyAuthorized

## :recycle: Current situation & Problem
- Problem: the `isFullyAuthorized` property is currently only updated when the app explicitly calls one of the askForAuthorization methods. This is bad bc it might not always happen. Plus, there can be cases where an app has already asked for authorization in the past, and technically doesn't need to do so anymore.
- Solution: We update the property in more cases, to make sure its value is correct in more situations.


## :gear: Release Notes 
- fix `isFullyAuthorized` sometimes not being updated if the application doesn't call `askForAuthorization`

## :books: Documentation
n/a

## :white_check_mark: Testing
n/a

## :pencil: Code of Conduct & Contributing Guidelines 
By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
