### PR TITLE
update `HealthKitConstraint` protocol to operate on batches of samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,16 +35,22 @@ You need to add the Spezi HealthKit Swift package to
 ### Health Data Collection
 
 Before you configure the [`HealthKit`](https://swiftpackageindex.com/stanfordspezi/spezihealthkit/documentation/spezihealthkit/healthkit-swift.class)  module, make sure your `Standard` in your Spezi Application conforms to the [`HealthKitConstraint`](https://swiftpackageindex.com/stanfordspezi/spezihealthkit/documentation/spezihealthkit/healthkitconstraint) protocol to receive HealthKit data.
-The [`HealthKitConstraint/add(sample:)`](https://swiftpackageindex.com/stanfordspezi/spezihealthkit/documentation/spezihealthkit/healthkitconstraint/add(sample:)) function is called once for every newly collected HealthKit sample, and the [`HealthKitConstraint/remove(sample:)`](https://swiftpackageindex.com/stanfordspezi/spezihealthkit/documentation/spezihealthkit/healthkitconstraint/remove(sample:)) function is called once for every deleted HealthKit sample.
+The [`HealthKitConstraint/handleNewSamples(_:ofType:)`](https://swiftpackageindex.com/stanfordspezi/spezihealthkit/documentation/spezihealthkit/healthkitconstraint/handleNewSamples(_:ofType:)) function is called once for every batch of newly collected HealthKit samples, and the [`HealthKitConstraint/handleDeletedObjects(_:ofType:)`](https://swiftpackageindex.com/stanfordspezi/spezihealthkit/documentation/spezihealthkit/healthkitconstraint/handleDeletedObjects(_:ofType:)) function is called once for every batch of deleted HealthKit objects.
 ```swift
 actor ExampleStandard: Standard, HealthKitConstraint {
-    // Add the newly collected HKSample to your application.
-    func add(sample: HKSample) async {
+    // Add the newly collected HealthKit samples to your application.
+    func handleNewSamples<Sample>(
+        _ addedSamples: some Collection<Sample>,
+        ofType sampleType: SampleType<Sample>
+    ) async {
         // ...
     }
 
-    // Remove the deleted HKSample from your application.
-    func remove(sample: HKDeletedObject) {
+    // Remove the deleted HealthKit objects from your application.
+    func handleDeletedObjects<Sample>(
+        _ deletedObjects: some Collection<HKDeletedObject>,
+        ofType sampleType: SampleType<Sample>
+    ) async {
         // ...
     }
 }

--- a/Sources/SpeziHealthKit/HealthKitConstraint.swift
+++ b/Sources/SpeziHealthKit/HealthKitConstraint.swift
@@ -14,27 +14,39 @@ import Spezi
 ///
 /// Make sure that your standard in your Spezi Application conforms to the ``HealthKitConstraint``
 /// protocol to receive HealthKit data.
-/// The ``HealthKitConstraint/add(sample:)`` function is triggered once for every newly collected HealthKit sample, and the ``HealthKitConstraint/remove(sample:)`` function is triggered once for every deleted HealthKit sample.
+/// The ``HealthKitConstraint/handleNewSamples(_:ofType:)`` function is triggered once for every batch of newly collected HealthKit samples, and ``HealthKitConstraint/handleDeletedObjects(_:ofType:)`` once for every batch of deleted HealthKit objects.
 /// ```swift
 /// actor ExampleStandard: Standard, HealthKitConstraint {
-///     // Add the newly collected HKSample to your application.
-///     func add(sample: HKSample) async {
+///     // Add the newly collected `HKSample`s to your application.
+///     func handleNewSamples<Sample>(
+///         _ addedSamples: some Collection<Sample>,
+///         ofType sampleType: SampleType<Sample>
+///     ) async {
 ///         // ...
 ///     }
 ///
-///     // Remove the deleted HKSample from your application.
-///     func remove(sample: HKDeletedObject) {
+///     // Remove the deleted `HKObject`s from your application.
+///     func handleDeletedObjects<Sample>(
+///         _ deletedObjects: some Collection<HKDeletedObject>,
+///         ofType sampleType: SampleType<Sample>
+///     ) async {
 ///         // ...
 ///     }
 /// }
 /// ```
 ///
 public protocol HealthKitConstraint: Standard {
-    /// Notifies the `Standard` about the addition of a HealthKit `HKSample` sample instance.
-    /// - Parameter sample: The `HKSample` that should be added.
-    func add(sample: HKSample) async
+    /// Notifies the `Standard` about the addition of a batch of HealthKit `HKSample` samples.
+    /// - Parameter addedSamples: The `HKSample`s that were added to the HealthKit database.
+    func handleNewSamples<Sample>(
+        _ addedSamples: some Collection<Sample>,
+        ofType sampleType: SampleType<Sample>
+    ) async
     
-    /// Notifies the `Standard` about the removal of a HealthKit sample as defined by the `HKDeletedObject`.
-    /// - Parameter sample: The `HKDeletedObject` is a sample that should be removed.
-    func remove(sample: HKDeletedObject) async
+    /// Notifies the `Standard` about the removal of a batch of HealthKit objects.
+    /// - Parameter deletedObjects: The `HKDeletedObject`s that were removed from the HealthKit database
+    func handleDeletedObjects<Sample>(
+        _ deletedObjects: some Collection<HKDeletedObject>,
+        ofType sampleType: SampleType<Sample>
+    ) async
 }

--- a/Sources/SpeziHealthKit/SpeziHealthKit.docc/SpeziHealthKit.md
+++ b/Sources/SpeziHealthKit/SpeziHealthKit.docc/SpeziHealthKit.md
@@ -28,16 +28,22 @@ You need to add the Spezi HealthKit Swift package to
 ### Example
 
 Before you configure the ``HealthKit-class`` module, make sure your `Standard` in your Spezi Application conforms to the ``HealthKitConstraint`` protocol to receive HealthKit data.
-The ``HealthKitConstraint/add(sample:)`` function is called once for every newly collected HealthKit sample, and the ``HealthKitConstraint/remove(sample:)`` function is called once for every deleted HealthKit sample.
+The ``HealthKitConstraint/handleNewSamples(_:ofType:)`` function is called once for every batch of newly collected HealthKit samples, and the ``HealthKitConstraint/handleDeletedObjects(_:ofType:)`` function is called once for every batch of deleted HealthKit objects.
 ```swift
 actor ExampleStandard: Standard, HealthKitConstraint {
-    // Add the newly collected HKSample to your application.
-    func add(sample: HKSample) async {
+    // Add the newly collected HealthKit samples to your application.
+    func handleNewSamples<Sample>(
+        _ addedSamples: some Collection<Sample>,
+        ofType sampleType: SampleType<Sample>
+    ) async {
         // ...
     }
 
-    // Remove the deleted HKSample from your application.
-    func remove(sample: HKDeletedObject) {
+    // Remove the deleted HealthKit objects from your application.
+    func handleDeletedObjects<Sample>(
+        _ deletedObjects: some Collection<HKDeletedObject>,
+        ofType sampleType: SampleType<Sample>
+    ) async {
         // ...
     }
 }

--- a/Tests/SpeziHealthKitTests/HealthDataCollectorRegistrationTests.swift
+++ b/Tests/SpeziHealthKitTests/HealthDataCollectorRegistrationTests.swift
@@ -14,8 +14,14 @@ import XCTSpezi
 
 
 private actor TestStandard: Standard, HealthKitConstraint {
-    func add(sample: HKSample) async {}
-    func remove(sample: HKDeletedObject) async {}
+    func handleNewSamples<Sample>(
+        _ addedSamples: some Collection<Sample>,
+        ofType sampleType: SampleType<Sample>
+    ) async {}
+    func handleDeletedObjects<Sample>(
+        _ deletedObjects: some Collection<HKDeletedObject>,
+        ofType sampleType: SampleType<Sample>
+    ) async {}
 }
 
 

--- a/Tests/UITests/TestApp/FakeHealthStore.swift
+++ b/Tests/UITests/TestApp/FakeHealthStore.swift
@@ -54,7 +54,7 @@ final class FakeHealthStore: Module, DefaultInitializable, EnvironmentAccessible
     }
     
     @MainActor
-    func add(sample: HKSample) async {
+    func add(_ sample: HKSample) async {
         logger.debug("Added sample: \(sample.debugDescription)")
         
         samples.append(sample)
@@ -83,16 +83,16 @@ final class FakeHealthStore: Module, DefaultInitializable, EnvironmentAccessible
     }
     
     @MainActor
-    func remove(sample: HKDeletedObject) async {
-        logger.debug("Removed sample: \(sample.debugDescription)")
-        if let index = samples.firstIndex(where: { $0.uuid == sample.uuid }) {
+    func remove(_ object: HKDeletedObject) async {
+        logger.debug("Removed sample: \(object.debugDescription)")
+        if let index = samples.firstIndex(where: { $0.uuid == object.uuid }) {
             samples.remove(at: index)
         }
-        backgroundPersistance.insert(.init(sample), at: 0)
+        backgroundPersistance.insert(.init(object), at: 0)
         
         let content = UNMutableNotificationContent()
         content.title = "Spezi HealthKit Test App"
-        content.body = "Removed sample: \(sample.uuid) at \(Date.now.formatted(date: .numeric, time: .complete))"
+        content.body = "Removed sample: \(object.uuid) at \(Date.now.formatted(date: .numeric, time: .complete))"
         let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: nil)
         try? await UNUserNotificationCenter.current().add(request)
     }

--- a/Tests/UITests/TestApp/HealthKitTestAppStandard.swift
+++ b/Tests/UITests/TestApp/HealthKitTestAppStandard.swift
@@ -15,11 +15,21 @@ import SpeziHealthKit
 actor HealthKitTestAppStandard: Standard, HealthKitConstraint {
     @Dependency(FakeHealthStore.self) private var fakeHealthStore
     
-    func add(sample: HKSample) async {
-        await fakeHealthStore.add(sample: sample)
+    func handleNewSamples<Sample>(
+        _ addedSamples: some Collection<Sample>,
+        ofType sampleType: SampleType<Sample>
+    ) async {
+        for sample in addedSamples {
+            await fakeHealthStore.add(sample)
+        }
     }
     
-    func remove(sample: HKDeletedObject) async {
-        await fakeHealthStore.remove(sample: sample)
+    func handleDeletedObjects<Sample>(
+        _ deletedObjects: some Collection<HKDeletedObject>,
+        ofType sampleType: SampleType<Sample>
+    ) async {
+        for object in deletedObjects {
+            await fakeHealthStore.remove(object)
+        }
     }
 }


### PR DESCRIPTION
# update `HealthKitConstraint` protocol to operate on batches of samples

## :recycle: Current situation & Problem
Currently, the `HealthKitConstraint` protocol operates on individual samples, even though HealthKit actually delivers information about added to / deleted from the HealthKit database in batches.
In all places where we propagate HealthKit changes to the Constraint, we do so in a for loop over a batch of added/deleted samples, calling the Constraint's `add(sample:)` and `remove(sample:)` functions once per added/removed object.

This PR changes the Constraint to instead operate on a collection of samples. This allows us to pass the entire batch to the Constraint, which in turn enables apps to implement their added/deleted sample handling in potentially more efficient ways.
For example, an app that uploads all collected samples to a server can do so in a single upload operation, instead of having to initiate and perform a large number of individual operations, therefore potentially being able to improve performance.

Furthermore, we also use this opportunity to add a sample type parameter to the functions.


## :gear: Release Notes
- Replaced `HealthKitConstraint.add(sample:)` with `HealthKitConstraint.handleNewSamples(_:ofType:)`
- Replaced `HealthKitConstraint.remove(sample:)` with `HealthKitConstraint.handleDeletedObjects(_:ofType:)`


## :books: Documentation
The documentation has been updated.


## :white_check_mark: Testing
The tests have been updated. There are no new tests, as this PR doesn't add any new functionality.


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
