### PR TITLE
make pausing and terminating sessions async operations

### DIFF
--- a/Sources/SpeziHealthKitBulkExport/BulkExportSession.swift
+++ b/Sources/SpeziHealthKitBulkExport/BulkExportSession.swift
@@ -53,8 +53,8 @@ public enum StartSessionError: Error {
 /// - ``currentBatch``
 /// - ``progress``
 /// ### Instance Methods
-/// - ``start(retryFailedBatches:)-8jsxv``
-/// - ``start(retryFailedBatches:)-571v3``
+/// - ``start(retryFailedBatches:)-23rws``
+/// - ``start(retryFailedBatches:)-9dmk0``
 /// - ``pause()``
 /// ### Other
 /// - ``SpeziHealthKitBulkExport/==(_:_:)``
@@ -97,10 +97,18 @@ public protocol BulkExportSession<Processor>: AnyObject, Hashable, Sendable, Obs
     ///
     /// This operation won't necessarily cause the session to get paused immediately.
     /// The session will complete its current block of work, and will only see the `pause()` call before starting the next work block.
-    @MainActor func pause()
+    ///
+    /// - Note: This is an asyncronous operation. The call will return once the pause request has been processed,
+    ///     which may take a little bit, e.g. if a ``BatchProcessor`` is performing a long-running operation.
+    ///     Place the call inside a `Task` if you don't want to wait for this.
+    @MainActor func pause() async
     
     /// Irrevocably terminates the session and detaches it from the ``BulkHealthExporter``.
-    @MainActor func _terminate() // swiftlint:disable:this identifier_name
+    ///
+    /// - Note: This is an asyncronous operation. The call will return once the termination request has been processed,
+    ///     which may take a little bit, e.g. if a ``BatchProcessor`` is performing a long-running operation.
+    ///     Place the call inside a `Task` if you don't want to wait for this.
+    @MainActor func _terminate() async // swiftlint:disable:this identifier_name
 }
 
 

--- a/Tests/UITests/TestApp/HealthKitTestsView/BulkExportView.swift
+++ b/Tests/UITests/TestApp/HealthKitTestsView/BulkExportView.swift
@@ -112,7 +112,7 @@ struct BulkExportView: View {
             precondition(session1 == session2)
         }
         AsyncButton("Reset ExportSession", role: .destructive, state: $viewState) {
-            try bulkExporter.deleteSessionRestorationInfo(for: sessionId)
+            try await bulkExporter.deleteSessionRestorationInfo(for: sessionId)
         }
     }
     
@@ -142,8 +142,8 @@ struct BulkExportView: View {
                     try imp(session)
                 }
             case .running:
-                Button("Pause") {
-                    session.pause()
+                AsyncButton("Pause", state: $viewState) {
+                    await session.pause()
                 }
             case .terminated:
                 EmptyView()


### PR DESCRIPTION
# make pausing and terminating sessions async operations

## :recycle: Current situation & Problem
This PR changes the `pause()`, `deleteSessionRestorationInfo()`, and `_terminate()` APIs into asyncronous functions, to allow callers to know when the operations actually complete.

## :gear: Release Notes
- made `ExportSession.pause()` and `BulkHealthExporter.deleteSessionRestorationInfo()` async


## :books: Documentation
The changes are documented and explained.


## :white_check_mark: Testing
the tests have been adjusted


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
