### PR TITLE
add 2 missing object types to `HKObjectType -> any AnySampleType` mapping

### DIFF
--- a/Sources/SpeziHealthKit/Sample Types/AnySampleType.swift
+++ b/Sources/SpeziHealthKit/Sample Types/AnySampleType.swift
@@ -136,6 +136,10 @@ extension HKObjectType {
             SampleType<HKCategorySample>(.init(rawValue: self.identifier))
         case is HKWorkoutType:
             SampleType.workout
+        case is HKElectrocardiogramType:
+            SampleType.electrocardiogram
+        case is HKAudiogramSampleType
+            SampleType.audiogram
         case is HKCharacteristicType, is HKDocumentType, is HKActivitySummaryType, is HKSeriesType:
             nil
         default:

--- a/Sources/SpeziHealthKit/Sample Types/AnySampleType.swift
+++ b/Sources/SpeziHealthKit/Sample Types/AnySampleType.swift
@@ -138,7 +138,7 @@ extension HKObjectType {
             SampleType.workout
         case is HKElectrocardiogramType:
             SampleType.electrocardiogram
-        case is HKAudiogramSampleType
+        case is HKAudiogramSampleType:
             SampleType.audiogram
         case is HKCharacteristicType, is HKDocumentType, is HKActivitySummaryType, is HKSeriesType:
             nil


### PR DESCRIPTION
# add 2 missing object types to `HKObjectType -> any AnySampleType` mapping

## :recycle: Current situation & Problem
This PR improves `HKObjectType.sampleType` to also support ECG and Audiogram Sample Types.


## :gear: Release Notes
- improved `HKObjectType.sampleType` to also support ECG and Audiogram Sample Types.


## :books: Documentation
n/a


## :white_check_mark: Testing
n/a

## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
