### PR TITLE
authorization observation mechanism; other small changes

### DIFF
--- a/Sources/SpeziHealthKit/Health Data Collection/HealthKitSampleCollector.swift
+++ b/Sources/SpeziHealthKit/Health Data Collection/HealthKitSampleCollector.swift
@@ -93,7 +93,8 @@ final class HealthKitSampleCollector<Sample: _HKSampleWithSampleType>: HealthDat
                         guard !sampleTypes.isEmpty else {
                             return
                         }
-                        guard sampleTypes.contains(self.sampleType.hkSampleType) else {
+                        let expectedSampleTypes = self.sampleType.effectiveSampleTypesForAuthentication.compactMapIntoSet { $0.hkSampleType }
+                        guard !sampleTypes.isDisjoint(with: expectedSampleTypes) else {
                             self.healthKit.logger.warning("Received Observation query types (\(sampleTypes)) are not corresponding to the CollectSample type \(self.sampleType.hkSampleType)")
                             return
                         }

--- a/Sources/SpeziHealthKit/Health Data Collection/HealthKitSampleCollector.swift
+++ b/Sources/SpeziHealthKit/Health Data Collection/HealthKitSampleCollector.swift
@@ -192,7 +192,7 @@ extension HealthKitQueryTimeRange {
     /// The purpose here is that we want to start the data collection at the previous full minute mark,
     /// to make it deterministic to manually entered data in HealthKit.
     func adjustedToWholeMinute() -> Self {
-        let cal = Calendar(identifier: .gregorian)
+        let cal = Calendar.current
         func imp(_ date: Date) -> Date {
             var components = cal.dateComponents(in: .current, from: date)
             components.second = 0

--- a/Sources/SpeziHealthKit/HealthKit Extensions/HKBloodType+Extensions.swift
+++ b/Sources/SpeziHealthKit/HealthKit Extensions/HKBloodType+Extensions.swift
@@ -1,0 +1,37 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import HealthKit
+
+
+extension HKBloodType {
+    /// All known Blood Types
+    public static let allKnownValues: [Self] = [
+        .notSet,
+        .aPositive, .aNegative,
+        .bPositive, .bNegative,
+        .abPositive, .abNegative,
+        .oPositive, .oNegative
+    ]
+    
+    /// The blood type's title, suitable for user-visible contexts.
+    public var displayTitle: LocalizedStringResource {
+        switch self {
+        case .notSet: "Not Set"
+        case .aPositive: "A+"
+        case .aNegative: "A-"
+        case .bPositive: "B+"
+        case .bNegative: "B-"
+        case .abPositive: "AB+"
+        case .abNegative: "AB-"
+        case .oPositive: "O+"
+        case .oNegative: "O-"
+        @unknown default: "Unknown"
+        }
+    }
+}

--- a/Sources/SpeziHealthKit/HealthKit Extensions/HKHealthStore+BackgroundDelivery.swift
+++ b/Sources/SpeziHealthKit/HealthKit Extensions/HKHealthStore+BackgroundDelivery.swift
@@ -39,9 +39,10 @@ extension HKHealthStore {
             Result<(sampleTypes: Set<HKSampleType>, completionHandler: HKObserverQueryCompletionHandler), any Error>
         ) async -> Void
     ) async throws -> BackgroundObserverQueryInvalidator {
-        let queryDescriptors: [HKQueryDescriptor] = sampleTypes.map {
-            HKQueryDescriptor(sampleType: $0, predicate: predicate)
-        }
+        let queryDescriptors: [HKQueryDescriptor] = sampleTypes
+            .flatMap { $0.effectiveObjectTypesForAuthentication }
+            .compactMap { $0 as? HKSampleType }
+            .map { HKQueryDescriptor(sampleType: $0, predicate: predicate) }
         let observerQuery = HKObserverQuery(queryDescriptors: queryDescriptors) { query, sampleTypes, completionHandler, error in
             // From https://developer.apple.com/documentation/healthkit/hkobserverquery/executing_observer_queries
             // "Whenever a matching sample is added to or deleted from the HealthKit store,

--- a/Sources/SpeziHealthKit/Resources/Localizable.xcstrings
+++ b/Sources/SpeziHealthKit/Resources/Localizable.xcstrings
@@ -1,6 +1,18 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "A-" : {
+
+    },
+    "A+" : {
+
+    },
+    "AB-" : {
+
+    },
+    "AB+" : {
+
+    },
     "Abdominal Cramps" : {
 
     },
@@ -48,6 +60,12 @@
           }
         }
       }
+    },
+    "B-" : {
+
+    },
+    "B+" : {
+
     },
     "Basal Body Temperature" : {
 
@@ -424,7 +442,16 @@
     "Night Sweats" : {
 
     },
+    "Not Set" : {
+
+    },
     "Number of Times Fallen" : {
+
+    },
+    "O-" : {
+
+    },
+    "O+" : {
 
     },
     "Ovulation Test Result" : {
@@ -620,6 +647,9 @@
 
     },
     "Underwater Depth" : {
+
+    },
+    "Unknown" : {
 
     },
     "UV Index" : {

--- a/Sources/SpeziHealthKit/Sample Types/HealthKitCharacteristic.swift
+++ b/Sources/SpeziHealthKit/Sample Types/HealthKitCharacteristic.swift
@@ -20,7 +20,7 @@ public protocol HealthKitCharacteristicProtocol<Value>: Hashable, Sendable {
     var displayTitle: String { get }
     
     /// Fetches the characteristic's value from a `HKHealthStore`.
-    @_spi(Internal)
+    @_spi(APISupport)
     func value(in healthStore: HKHealthStore) throws -> Value
 }
 
@@ -53,7 +53,7 @@ public struct HealthKitCharacteristic<Value>: HealthKitCharacteristicProtocol, S
         self.accessor = accessor
     }
     
-    @_spi(Internal)
+    @_spi(APISupport)
     public func value(in healthStore: HKHealthStore) throws -> Value {
         try accessor(healthStore)
     }

--- a/Sources/SpeziHealthKit/Sample Types/SampleTypeProxy.swift
+++ b/Sources/SpeziHealthKit/Sample Types/SampleTypeProxy.swift
@@ -161,3 +161,10 @@ extension SampleTypeProxy: Codable {
         try container.encode("\(classname);\(underlyingSampleType.hkSampleType.identifier)")
     }
 }
+
+
+/// Compare two sample types, based on their identifiers
+@inlinable // swiftlint:disable:next static_operator
+public func ~= (pattern: SampleType<some Any>, value: SampleTypeProxy) -> Bool {
+    pattern.id == value.id
+}

--- a/Sources/SpeziHealthKit/SpeziHealthKit.docc/SpeziHealthKit.md
+++ b/Sources/SpeziHealthKit/SpeziHealthKit.docc/SpeziHealthKit.md
@@ -107,3 +107,5 @@ class ExampleAppDelegate: SpeziAppDelegate {
 ### HealthKit Utilities
 - ``HealthKit/HKUnit/*(_:_:)``
 - ``HealthKit/HKUnit//(_:_:)``
+- ``HealthKit/HKBloodType/allKnownValues``
+- ``HealthKit/HKBloodType/displayTitle``

--- a/Sources/SpeziHealthKitBulkExport/BulkExportSessionDescriptor.swift
+++ b/Sources/SpeziHealthKitBulkExport/BulkExportSessionDescriptor.swift
@@ -24,37 +24,33 @@ struct ExportSessionDescriptor: Codable {
     let sessionId: BulkExportSessionIdentifier
     let startDate: ExportSessionStartDate
     let endDate: Date
-    let batchSize: ExportSessionBatchSize
     var pendingBatches: [ExportBatch]
     var completedBatches: [ExportBatch]
     
     init(
         sessionId: BulkExportSessionIdentifier,
         startDate: ExportSessionStartDate,
-        endDate: Date,
-        batchSize: ExportSessionBatchSize,
-        sampleTypes: SampleTypesCollection,
-        using healthKit: HealthKit
-    ) async {
+        endDate: Date
+    ) {
         self.sessionId = sessionId
         self.startDate = startDate
         self.endDate = endDate
-        self.batchSize = batchSize
-        self.completedBatches = []
         self.pendingBatches = []
-        for sampleType in sampleTypes {
-            await add(sampleType: sampleType, healthKit: healthKit)
-        }
+        self.completedBatches = []
     }
     
-    mutating func add<Sample>(sampleType: some AnySampleType<Sample>, healthKit: HealthKit) async {
+    mutating func add<Sample>(sampleType: some AnySampleType<Sample>, batchSize: ExportSessionBatchSize, healthKit: HealthKit) async {
+        await add(sampleType: SampleType(sampleType), batchSize: batchSize, healthKit: healthKit)
+    }
+    
+    mutating func add<Sample>(sampleType: SampleType<Sample>, batchSize: ExportSessionBatchSize, healthKit: HealthKit) async {
         let sampleType = SampleType(sampleType)
         guard !(pendingBatches + completedBatches).contains(where: { $0.sampleType == sampleType }) else {
             // we have at least one scheduled or already-completed batch with this sample type
             // --> nothing to be done; we're already handling it.
             return
         }
-        let cal = Calendar(identifier: .gregorian)
+        let cal = Calendar.current
         let startDate: Date = await startDate.startDate(for: sampleType, in: healthKit, relativeTo: self.endDate) ?? {
             // if we can't determine the oldest sample date, we use the day HealthKit was introduced as our fallback
             // Note: it could be that there's no oldest sample date because there are no samples for the sample type,
@@ -66,8 +62,14 @@ struct ExportSessionDescriptor: Codable {
         case .automatic:
             // guaranteed to be unreachable by resolveBatchSize()
             fatalError("unreachable")
-        case .calendarComponent(let component):
-            batchTimeRanges = Array(cal.ranges(of: component, startingAt: startDate, in: startDate..<endDate, clampToLimits: true))
+        case let .calendarComponent(component, multiplier):
+            batchTimeRanges = Array(cal.ranges(
+                of: component,
+                multiplier: multiplier,
+                startingAt: startDate,
+                in: startDate..<endDate,
+                clampToLimits: true
+            ))
         }
         pendingBatches.append(contentsOf: batchTimeRanges.map { timeRange in
             ExportBatch(sampleType: sampleType, timeRange: timeRange)
@@ -101,10 +103,10 @@ extension ExportSessionDescriptor {
                 SampleType.distanceWalkingRunning, SampleType.physicalEffort, SampleType.stepCount:
                 .byMonth
             default:
-                .byYear
+                .calendarComponent(.month, multiplier: 6)
             }
-        case .calendarComponent(let component):
-            .calendarComponent(component)
+        case .calendarComponent:
+            batchSize
         }
     }
 }

--- a/Sources/SpeziHealthKitBulkExport/BulkExportSessionDescriptor.swift
+++ b/Sources/SpeziHealthKitBulkExport/BulkExportSessionDescriptor.swift
@@ -88,6 +88,7 @@ struct ExportSessionDescriptor: Codable {
     }
 }
 
+
 extension ExportSessionDescriptor {
     /// Determines a resolved batch size, based on an input batch size and a sample type.
     ///
@@ -96,7 +97,8 @@ extension ExportSessionDescriptor {
         switch batchSize {
         case .automatic:
             switch sampleType {
-            case SampleType.activeEnergyBurned, SampleType.stepCount, SampleType.heartRate:
+            case SampleType.activeEnergyBurned, SampleType.basalEnergyBurned, SampleType.heartRate,
+                SampleType.distanceWalkingRunning, SampleType.physicalEffort, SampleType.stepCount:
                 .byMonth
             default:
                 .byYear

--- a/Sources/SpeziHealthKitBulkExport/BulkExportSessionImpl.swift
+++ b/Sources/SpeziHealthKitBulkExport/BulkExportSessionImpl.swift
@@ -100,14 +100,15 @@ final class BulkExportSessionImpl<Processor: BatchProcessor>: Sendable, BulkExpo
         } else {
             // if there's no persisted state for this session identifier, we create a new descriptor,
             // which will operate on all samples created up until right now.
-            self.descriptor = await ExportSessionDescriptor(
+            var descriptor = ExportSessionDescriptor(
                 sessionId: sessionId,
                 startDate: startDate,
                 endDate: endDate,
-                batchSize: batchSize,
-                sampleTypes: sampleTypes,
-                using: healthKit
             )
+            for sampleType in sampleTypes {
+                await descriptor.add(sampleType: sampleType, batchSize: batchSize, healthKit: healthKit)
+            }
+            self.descriptor = descriptor
         }
     }
 }

--- a/Sources/SpeziHealthKitBulkExport/CalendarUtils.swift
+++ b/Sources/SpeziHealthKitBulkExport/CalendarUtils.swift
@@ -56,10 +56,12 @@ extension Calendar.Component {
 extension Calendar {
     func ranges(
         of component: ComponentForIteration,
+        multiplier: Int = 1,
         startingAt start: Date,
         in limitRange: Range<Date>,
         clampToLimits: Bool
     ) -> some Sendable & Sequence<Range<Date>> {
+        precondition(multiplier >= 1, "Invalid multiplier value")
         struct Iterator: IteratorProtocol, Sendable {
             typealias Element = Range<Date>
             let cal: Calendar
@@ -88,7 +90,7 @@ extension Calendar {
             cal: self,
             componentsToAdd: {
                 var components = DateComponents()
-                components.setValue(1, for: .init(component))
+                components.setValue(multiplier, for: .init(component))
                 return components
             }(),
             limitRange: limitRange,

--- a/Sources/SpeziHealthKitBulkExport/CalendarUtils.swift
+++ b/Sources/SpeziHealthKitBulkExport/CalendarUtils.swift
@@ -56,7 +56,7 @@ extension Calendar.Component {
 extension Calendar {
     func ranges(
         of component: ComponentForIteration,
-        multiplier: Int = 1,
+        multiplier: Int = 1, // swiftlint:disable:this function_default_parameter_at_end
         startingAt start: Date,
         in limitRange: Range<Date>,
         clampToLimits: Bool

--- a/Sources/SpeziHealthKitBulkExport/ExportSessionBatchSize.swift
+++ b/Sources/SpeziHealthKitBulkExport/ExportSessionBatchSize.swift
@@ -15,8 +15,12 @@ public enum ExportSessionBatchSize: Hashable, Codable, Sendable {
     ///
     /// This is the recommended option, since it allows for the greatest possible efficiency w.r.t. resource usage and performance.
     case automatic
-    /// The export session should, for every sample type, create one batch for every range of the specified calendar component, within the total time range for which data is being exported.
-    case calendarComponent(Calendar.ComponentForIteration)
+    /// The export session should, for every sample type, create one batch for every range of the specified calendar component,  within the total time range for which data is being exported.
+    ///
+    /// - parameter component: The calendar component on which the batch size should be based
+    /// - parameter multiplier: How many instances of the component the batch should span.
+    ///     For example, `.calendarComponent(.week, multiplier: 2)` would result in each batch covering two weeks.
+    case calendarComponent(_ component: Calendar.ComponentForIteration, multiplier: Int = 1)
     
     /// The export session should, for every sample type, create one batch for every year of data being exported.
     public static var byYear: Self {

--- a/Sources/SpeziHealthKitUI/HealthAccessAuthorizationObserver.swift
+++ b/Sources/SpeziHealthKitUI/HealthAccessAuthorizationObserver.swift
@@ -1,0 +1,67 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+@_spi(APISupport) import SpeziHealthKit
+import SwiftUI
+
+
+@propertyWrapper
+struct HealthAccessAuthorizationObserver: DynamicProperty {
+    @Observable
+    fileprivate final class Storage: @unchecked Sendable {
+        final class ActionBox {
+            var imp: @Sendable () async -> Void
+            init(_ imp: @escaping @Sendable () async -> Void) {
+                self.imp = imp
+            }
+        }
+        final class Entry {
+            let task: Task<Void, Never>
+            let action: ActionBox
+            init(task: Task<Void, Never>, action: ActionBox) {
+                self.task = task
+                self.action = action
+            }
+        }
+        
+        @ObservationIgnored var entries: [HealthKit.DataAccessRequirements: Entry] = [:]
+        nonisolated init() {}
+        deinit {
+            // not sure who else is retaining the tasks, but we need to explicitly cancel them here for some reason...
+            for (_, entry) in entries {
+                entry.task.cancel()
+            }
+        }
+    }
+    
+    @Environment(HealthKit.self) private var healthKit
+    @State private var storage = Storage()
+    
+    var wrappedValue: Self {
+        self
+    }
+    
+    init() {}
+    
+    @MainActor
+    func observeAuthorizationChanges(for accessReqs: HealthKit.DataAccessRequirements, _ handler: @escaping @Sendable () async -> Void) {
+        if let entry = storage.entries[accessReqs] {
+            entry.action.imp = handler
+        } else {
+            let actionBox = Storage.ActionBox(handler)
+            let task = Task { [healthKit, actionBox] in
+                let stream = healthKit.observeAuthenticationEvents(matching: accessReqs)
+                for await _ in stream {
+                    await actionBox.imp()
+                }
+            }
+            let entry = Storage.Entry(task: task, action: actionBox)
+            storage.entries[accessReqs] = entry
+        }
+    }
+}

--- a/Sources/SpeziHealthKitUI/Queries/HealthKitQuery.swift
+++ b/Sources/SpeziHealthKitUI/Queries/HealthKitQuery.swift
@@ -61,6 +61,8 @@ public struct HealthKitQuery<Sample: _HKSampleWithSampleType>: DynamicProperty {
     @State
     private var results = SamplesQueryResults<Sample>()
     
+    @HealthAccessAuthorizationObserver private var accessAuthObserver
+    
     /// The individual query results.
     ///
     /// - Note: This property is a `RandomAccessCollection<Sample>`; the specific type is an implementation detail and may change.
@@ -116,6 +118,10 @@ public struct HealthKitQuery<Sample: _HKSampleWithSampleType>: DynamicProperty {
                 healthKit: healthKit,
                 input: input
             )
+            let accessReqs = HealthKit.DataAccessRequirements(read: [input.sampleType.hkSampleType])
+            accessAuthObserver.observeAuthorizationChanges(for: accessReqs) { [results, healthKit, input] in
+                await results.initializeSwiftUIManagedQuery(healthKit: healthKit, input: input, forceUpdate: true)
+            }
         }
     }
 }
@@ -150,6 +156,9 @@ public final class SamplesQueryResults<Sample: _HKSampleWithSampleType>: @unchec
     @ObservationIgnored
     private var queryTask: Task<Void, Never>?
     
+    @ObservationIgnored
+    private var authorizationObserverTask: Task<Void, Never>?
+    
     public private(set) var isCurrentlyPerformingInitialFetch: Bool = false
     public private(set) var queryError: (any Error)?
     
@@ -172,8 +181,8 @@ public final class SamplesQueryResults<Sample: _HKSampleWithSampleType>: @unchec
     
     
     @MainActor
-    fileprivate func initializeSwiftUIManagedQuery(healthKit: HealthKit, input: Input) {
-        guard self.input != input else {
+    fileprivate func initializeSwiftUIManagedQuery(healthKit: HealthKit, input: Input, forceUpdate: Bool = false) {
+        guard forceUpdate || self.input != input else {
             return
         }
         self.healthKit = healthKit

--- a/Tests/SpeziHealthKitTests/BulkExporterAPITests.swift
+++ b/Tests/SpeziHealthKitTests/BulkExporterAPITests.swift
@@ -99,7 +99,9 @@ struct BulkExporterAPITests {
             try #require(cal.date(from: .init(year: year, month: month, day: day)), sourceLocation: location)
         }
         
-        let dayAdj = -(2 - Calendar.current.firstWeekday)
+        // needed to support running the test in both locales that start the week on monday and on sunday.
+        // the test case below assumes monday as start of week.
+        let dayAdj = -(2 - cal.firstWeekday)
         
         var sessionDescriptor = ExportSessionDescriptor(
             sessionId: .init(UUID().uuidString),
@@ -139,20 +141,20 @@ struct BulkExporterAPITests {
         await sessionDescriptor.add(sampleType: .activeEnergyBurned, batchSize: .calendarComponent(.week, multiplier: 2), healthKit: healthKit)
         #expect(batches(for: .activeEnergyBurned).count == 14)
         #expect(batches(for: .activeEnergyBurned).starts(with: [
-            .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 1, 24)..<makeDate(2025, 2, 3)),
-            .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 2, 3)..<makeDate(2025, 2, 17)),
-            .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 2, 17)..<makeDate(2025, 3, 3)),
-            .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 3, 3)..<makeDate(2025, 3, 17)),
-            .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 3, 17)..<makeDate(2025, 3, 31)),
-            .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 3, 31)..<makeDate(2025, 4, 14)),
-            .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 4, 14)..<makeDate(2025, 4, 28)),
-            .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 4, 28)..<makeDate(2025, 5, 12)),
-            .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 5, 12)..<makeDate(2025, 5, 26)),
-            .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 5, 26)..<makeDate(2025, 6, 9)),
-            .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 6, 9)..<makeDate(2025, 6, 23)),
-            .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 6, 23)..<makeDate(2025, 7, 7)),
-            .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 7, 7)..<makeDate(2025, 7, 21)),
-            .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 7, 21)..<makeDate(2025, 7, 24))
+            .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 1, 24)..<makeDate(2025, 2, 3 + dayAdj)),
+            .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 2, 3 + dayAdj)..<makeDate(2025, 2, 17 + dayAdj)),
+            .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 2, 17 + dayAdj)..<makeDate(2025, 3, 3 + dayAdj)),
+            .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 3, 3 + dayAdj)..<makeDate(2025, 3, 17 + dayAdj)),
+            .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 3, 17 + dayAdj)..<makeDate(2025, 3, 31 + dayAdj)),
+            .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 3, 31 + dayAdj)..<makeDate(2025, 4, 14 + dayAdj)),
+            .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 4, 14 + dayAdj)..<makeDate(2025, 4, 28 + dayAdj)),
+            .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 4, 28 + dayAdj)..<makeDate(2025, 5, 12 + dayAdj)),
+            .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 5, 12 + dayAdj)..<makeDate(2025, 5, 26 + dayAdj)),
+            .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 5, 26 + dayAdj)..<makeDate(2025, 6, 9 + dayAdj)),
+            .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 6, 9 + dayAdj)..<makeDate(2025, 6, 23 + dayAdj)),
+            .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 6, 23 + dayAdj)..<makeDate(2025, 7, 7 + dayAdj)),
+            .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 7, 7 + dayAdj)..<makeDate(2025, 7, 21 + dayAdj)),
+            .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 7, 21 + dayAdj)..<makeDate(2025, 7, 24))
         ]))
     }
 }

--- a/Tests/SpeziHealthKitTests/BulkExporterAPITests.swift
+++ b/Tests/SpeziHealthKitTests/BulkExporterAPITests.swift
@@ -8,6 +8,7 @@
 
 // swiftlint:disable file_types_order
 
+import Algorithms
 import Spezi
 @testable import SpeziHealthKit
 @testable import SpeziHealthKitBulkExport
@@ -80,6 +81,73 @@ struct BulkExporterAPITests {
         try await module.deleteSessionRestorationInfo(for: sessionId)
         #expect(await session.state == .terminated)
         #expect(await module.sessions.isEmpty)
+    }
+    
+    
+    @Test
+    func exportBatchTimeRanges() async throws {
+        let cal = Calendar.current
+        let healthKit = HealthKit()
+        let bulkExporter = BulkHealthExporter()
+        await withDependencyResolution(standard: TestStandard()) {
+            healthKit
+            bulkExporter
+        }
+        #expect(await bulkExporter.sessions.isEmpty)
+        
+        func makeDate(_ year: Int, _ month: Int, _ day: Int, location: SourceLocation = #_sourceLocation) throws -> Date {
+            try #require(cal.date(from: .init(year: year, month: month, day: day)), sourceLocation: location)
+        }
+        
+        var sessionDescriptor = ExportSessionDescriptor(
+            sessionId: .init(UUID().uuidString),
+            startDate: .last(.init(month: 6)),
+            endDate: try makeDate(2025, 7, 26)
+        )
+        #expect(sessionDescriptor.pendingBatches.isEmpty)
+        #expect(sessionDescriptor.completedBatches.isEmpty)
+        #expect(try await sessionDescriptor.startDate.startDate(for: SampleType.heartRate, in: healthKit, relativeTo: sessionDescriptor.endDate) == makeDate(2025, 1, 26))
+        #expect(try cal.startOfWeek(for: makeDate(2025, 1, 26)) == makeDate(2025, 1, 20))
+        #expect(try cal.start(of: .week, for: makeDate(2025, 1, 26)) == makeDate(2025, 1, 20))
+        
+        func batches(for sampleType: SampleType<some Any>) -> [ExportBatch] {
+            sessionDescriptor.pendingBatches.filter { $0.sampleType == sampleType }
+        }
+        // add some export batches
+        await sessionDescriptor.add(sampleType: SampleType.heartRate, batchSize: .byMonth, healthKit: healthKit)
+        let heartRateExportBatches = batches(for: .heartRate)
+        #expect(heartRateExportBatches.count == 7)
+        // adding the same input again shouldn't affect anything
+        await sessionDescriptor.add(sampleType: SampleType.heartRate, batchSize: .byMonth, healthKit: healthKit)
+        #expect(batches(for: .heartRate) == heartRateExportBatches)
+        #expect(heartRateExportBatches == [
+            .init(sampleType: SampleType.heartRate, timeRange: try makeDate(2025, 1, 26)..<makeDate(2025, 2, 1)),
+            .init(sampleType: SampleType.heartRate, timeRange: try makeDate(2025, 2, 1)..<makeDate(2025, 3, 1)),
+            .init(sampleType: SampleType.heartRate, timeRange: try makeDate(2025, 3, 1)..<makeDate(2025, 4, 1)),
+            .init(sampleType: SampleType.heartRate, timeRange: try makeDate(2025, 4, 1)..<makeDate(2025, 5, 1)),
+            .init(sampleType: SampleType.heartRate, timeRange: try makeDate(2025, 5, 1)..<makeDate(2025, 6, 1)),
+            .init(sampleType: SampleType.heartRate, timeRange: try makeDate(2025, 6, 1)..<makeDate(2025, 7, 1)),
+            .init(sampleType: SampleType.heartRate, timeRange: try makeDate(2025, 7, 1)..<makeDate(2025, 7, 26)),
+        ])
+        
+        await sessionDescriptor.add(sampleType: .activeEnergyBurned, batchSize: .calendarComponent(.week, multiplier: 2), healthKit: healthKit)
+        #expect(batches(for: .activeEnergyBurned).count == 14)
+        #expect(batches(for: .activeEnergyBurned).starts(with: [
+            .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 1, 26)..<makeDate(2025, 2, 3)),
+            .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 2, 3)..<makeDate(2025, 2, 17)),
+            .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 2, 17)..<makeDate(2025, 3, 3)),
+            .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 3, 3)..<makeDate(2025, 3, 17)),
+            .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 3, 17)..<makeDate(2025, 3, 31)),
+            .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 3, 31)..<makeDate(2025, 4, 14)),
+            .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 4, 14)..<makeDate(2025, 4, 28)),
+            .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 4, 28)..<makeDate(2025, 5, 12)),
+            .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 5, 12)..<makeDate(2025, 5, 26)),
+            .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 5, 26)..<makeDate(2025, 6, 9)),
+            .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 6, 9)..<makeDate(2025, 6, 23)),
+            .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 6, 23)..<makeDate(2025, 7, 7)),
+            .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 7, 7)..<makeDate(2025, 7, 21)),
+            .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 7, 21)..<makeDate(2025, 7, 26)),
+        ]))
     }
 }
 

--- a/Tests/SpeziHealthKitTests/BulkExporterAPITests.swift
+++ b/Tests/SpeziHealthKitTests/BulkExporterAPITests.swift
@@ -99,10 +99,12 @@ struct BulkExporterAPITests {
             try #require(cal.date(from: .init(year: year, month: month, day: day)), sourceLocation: location)
         }
         
+        let dayAdj = -(2 - Calendar.current.firstWeekday)
+        
         var sessionDescriptor = ExportSessionDescriptor(
             sessionId: .init(UUID().uuidString),
             startDate: .last(.init(month: 6)),
-            endDate: try makeDate(2025, 7, 26)
+            endDate: try makeDate(2025, 7, 24)
         )
         #expect(sessionDescriptor.pendingBatches.isEmpty)
         #expect(sessionDescriptor.completedBatches.isEmpty)
@@ -110,9 +112,9 @@ struct BulkExporterAPITests {
             for: SampleType.heartRate,
             in: healthKit,
             relativeTo: sessionDescriptor.endDate
-        ) == makeDate(2025, 1, 26))
-        #expect(try cal.startOfWeek(for: makeDate(2025, 1, 26)) == makeDate(2025, 1, 20))
-        #expect(try cal.start(of: .week, for: makeDate(2025, 1, 26)) == makeDate(2025, 1, 20))
+        ) == makeDate(2025, 1, 24))
+        #expect(try cal.startOfWeek(for: makeDate(2025, 1, 24)) == makeDate(2025, 1, 20 + dayAdj))
+        #expect(try cal.start(of: .week, for: makeDate(2025, 1, 24)) == makeDate(2025, 1, 20 + dayAdj))
         
         func batches(for sampleType: SampleType<some Any>) -> [ExportBatch] {
             sessionDescriptor.pendingBatches.filter { $0.sampleType == sampleType }
@@ -125,19 +127,19 @@ struct BulkExporterAPITests {
         await sessionDescriptor.add(sampleType: SampleType.heartRate, batchSize: .byMonth, healthKit: healthKit)
         #expect(batches(for: .heartRate) == heartRateExportBatches)
         #expect(heartRateExportBatches == [
-            .init(sampleType: SampleType.heartRate, timeRange: try makeDate(2025, 1, 26)..<makeDate(2025, 2, 1)),
+            .init(sampleType: SampleType.heartRate, timeRange: try makeDate(2025, 1, 24)..<makeDate(2025, 2, 1)),
             .init(sampleType: SampleType.heartRate, timeRange: try makeDate(2025, 2, 1)..<makeDate(2025, 3, 1)),
             .init(sampleType: SampleType.heartRate, timeRange: try makeDate(2025, 3, 1)..<makeDate(2025, 4, 1)),
             .init(sampleType: SampleType.heartRate, timeRange: try makeDate(2025, 4, 1)..<makeDate(2025, 5, 1)),
             .init(sampleType: SampleType.heartRate, timeRange: try makeDate(2025, 5, 1)..<makeDate(2025, 6, 1)),
             .init(sampleType: SampleType.heartRate, timeRange: try makeDate(2025, 6, 1)..<makeDate(2025, 7, 1)),
-            .init(sampleType: SampleType.heartRate, timeRange: try makeDate(2025, 7, 1)..<makeDate(2025, 7, 26))
+            .init(sampleType: SampleType.heartRate, timeRange: try makeDate(2025, 7, 1)..<makeDate(2025, 7, 24))
         ])
         
         await sessionDescriptor.add(sampleType: .activeEnergyBurned, batchSize: .calendarComponent(.week, multiplier: 2), healthKit: healthKit)
         #expect(batches(for: .activeEnergyBurned).count == 14)
         #expect(batches(for: .activeEnergyBurned).starts(with: [
-            .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 1, 26)..<makeDate(2025, 2, 3)),
+            .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 1, 24)..<makeDate(2025, 2, 3)),
             .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 2, 3)..<makeDate(2025, 2, 17)),
             .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 2, 17)..<makeDate(2025, 3, 3)),
             .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 3, 3)..<makeDate(2025, 3, 17)),
@@ -150,7 +152,7 @@ struct BulkExporterAPITests {
             .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 6, 9)..<makeDate(2025, 6, 23)),
             .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 6, 23)..<makeDate(2025, 7, 7)),
             .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 7, 7)..<makeDate(2025, 7, 21)),
-            .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 7, 21)..<makeDate(2025, 7, 26))
+            .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 7, 21)..<makeDate(2025, 7, 24))
         ]))
     }
 }

--- a/Tests/SpeziHealthKitTests/BulkExporterAPITests.swift
+++ b/Tests/SpeziHealthKitTests/BulkExporterAPITests.swift
@@ -85,7 +85,7 @@ struct BulkExporterAPITests {
     
     
     @Test
-    func exportBatchTimeRanges() async throws {
+    func exportBatchTimeRanges() async throws { // swiftlint:disable:this function_body_length
         let cal = Calendar.current
         let healthKit = HealthKit()
         let bulkExporter = BulkHealthExporter()
@@ -106,7 +106,11 @@ struct BulkExporterAPITests {
         )
         #expect(sessionDescriptor.pendingBatches.isEmpty)
         #expect(sessionDescriptor.completedBatches.isEmpty)
-        #expect(try await sessionDescriptor.startDate.startDate(for: SampleType.heartRate, in: healthKit, relativeTo: sessionDescriptor.endDate) == makeDate(2025, 1, 26))
+        #expect(try await sessionDescriptor.startDate.startDate(
+            for: SampleType.heartRate,
+            in: healthKit,
+            relativeTo: sessionDescriptor.endDate
+        ) == makeDate(2025, 1, 26))
         #expect(try cal.startOfWeek(for: makeDate(2025, 1, 26)) == makeDate(2025, 1, 20))
         #expect(try cal.start(of: .week, for: makeDate(2025, 1, 26)) == makeDate(2025, 1, 20))
         
@@ -127,7 +131,7 @@ struct BulkExporterAPITests {
             .init(sampleType: SampleType.heartRate, timeRange: try makeDate(2025, 4, 1)..<makeDate(2025, 5, 1)),
             .init(sampleType: SampleType.heartRate, timeRange: try makeDate(2025, 5, 1)..<makeDate(2025, 6, 1)),
             .init(sampleType: SampleType.heartRate, timeRange: try makeDate(2025, 6, 1)..<makeDate(2025, 7, 1)),
-            .init(sampleType: SampleType.heartRate, timeRange: try makeDate(2025, 7, 1)..<makeDate(2025, 7, 26)),
+            .init(sampleType: SampleType.heartRate, timeRange: try makeDate(2025, 7, 1)..<makeDate(2025, 7, 26))
         ])
         
         await sessionDescriptor.add(sampleType: .activeEnergyBurned, batchSize: .calendarComponent(.week, multiplier: 2), healthKit: healthKit)
@@ -146,7 +150,7 @@ struct BulkExporterAPITests {
             .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 6, 9)..<makeDate(2025, 6, 23)),
             .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 6, 23)..<makeDate(2025, 7, 7)),
             .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 7, 7)..<makeDate(2025, 7, 21)),
-            .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 7, 21)..<makeDate(2025, 7, 26)),
+            .init(sampleType: SampleType.activeEnergyBurned, timeRange: try makeDate(2025, 7, 21)..<makeDate(2025, 7, 26))
         ]))
     }
 }

--- a/Tests/UITests/TestApp/HealthKitTestsView/ActionsMenu.swift
+++ b/Tests/UITests/TestApp/HealthKitTestsView/ActionsMenu.swift
@@ -29,6 +29,9 @@ struct ActionsMenu: View {
         ]),
         .init(sampleType: .height, samples: [
             .init(date: .now, value: 187, unit: .meterUnit(with: .centi))
+        ]),
+        .init(sampleType: .distanceCycling, samples: [
+            .init(date: .now, value: 52, unit: .meterUnit(with: .kilo))
         ])
     ]
     

--- a/Tests/UITests/TestApp/HealthKitTestsView/BulkExportView.swift
+++ b/Tests/UITests/TestApp/HealthKitTestsView/BulkExportView.swift
@@ -33,12 +33,11 @@ extension NSPredicate {
 
 
 struct BulkExportView: View {
-    @Environment(HealthKit.self)
-    private var healthKit
-    @Environment(BulkHealthExporter.self)
-    private var bulkExporter
-    @Environment(\.calendar)
-    private var cal
+    // swiftlint:disable attributes
+    @Environment(HealthKit.self) private var healthKit
+    @Environment(BulkHealthExporter.self) private var bulkExporter
+    @Environment(\.calendar) private var cal
+    // swiftlint:enable attributes
     
     // NOTE: we are intentionally using these specific sample types here, since they don't overlap with the `CollectSample` definitions.
     // Adding eg a ton of heart rate samples would slow down the app a lot, since they'd trigger the observer mechanism.

--- a/Tests/UITests/TestApp/HealthKitTestsView/CharacteristicsView.swift
+++ b/Tests/UITests/TestApp/HealthKitTestsView/CharacteristicsView.swift
@@ -9,6 +9,7 @@
 import HealthKit
 import SpeziHealthKit
 import SpeziHealthKitUI
+import SpeziViews
 import SwiftUI
 
 
@@ -34,7 +35,7 @@ struct CharacteristicsView: View {
     var body: some View {
         Form {
             makeRow("Move Mode", value: moveMode)
-            makeRow("Blood Type", value: bloodType)
+            LabeledContent("Blood Type", value: bloodType?.displayTitle.localizedString() ?? "n/a")
             LabeledContent("Date of Birth", value: dateOfBirth?.formatted(.iso8601) ?? "n/a")
             makeRow("Biological Sex", value: biologicalSex)
             makeRow("Skin Type", value: skinType)

--- a/Tests/UITests/TestApp/HealthKitTestsView/DeferredAuthorizationTests.swift
+++ b/Tests/UITests/TestApp/HealthKitTestsView/DeferredAuthorizationTests.swift
@@ -1,0 +1,49 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import HealthKit
+import SpeziHealthKit
+import SpeziHealthKitUI
+import SpeziViews
+import SwiftUI
+
+
+struct DeferredAuthorizationTests: View {
+    @Environment(HealthKit.self) var healthKit
+    @HealthKitCharacteristicQuery(.bloodType) private var bloodType
+    @Binding var viewState: ViewState
+    
+    @HealthKitQuery(.distanceCycling, timeRange: .ever)
+    private var cyclingDistanceSamples
+    @HealthKitStatisticsQuery(.distanceCycling, aggregatedBy: [.sum], over: .year, timeRange: .ever)
+    private var cyclingDistanceStats
+    
+    var body: some View {
+        Form {
+            Section {
+                LabeledContent("Blood Type", value: (bloodType?.displayTitle).map { String(localized: $0) } ?? "n/a")
+                LabeledContent("#cyclingSamples", value: cyclingDistanceSamples.count, format: .number)
+                LabeledContent(
+                    "#km cycled",
+                    // swiftlint:disable:next force_unwrapping
+                    value: cyclingDistanceStats.reduce(into: 0) { $0 += $1.sumQuantity()!.doubleValue(for: .meterUnit(with: .kilo)) },
+                    format: .number
+                )
+            }
+            Section {
+                AsyncButton("Request BloodType", state: $viewState) {
+                    try await healthKit.askForAuthorization(for: .init(read: [HKCharacteristicType(.bloodType)]))
+                }
+                AsyncButton("Request CyclingDistance", state: $viewState) {
+                    try await healthKit.askForAuthorization(for: .init(read: [HKQuantityType(.distanceCycling)]))
+                }
+            }
+        }
+    }
+}

--- a/Tests/UITests/TestApp/HealthKitTestsView/DeferredAuthorizationTests.swift
+++ b/Tests/UITests/TestApp/HealthKitTestsView/DeferredAuthorizationTests.swift
@@ -37,10 +37,10 @@ struct DeferredAuthorizationTests: View {
                 )
             }
             Section {
-                AsyncButton("Request BloodType", state: $viewState) {
+                AsyncButton("Request Blood Type", state: $viewState) {
                     try await healthKit.askForAuthorization(for: .init(read: [HKCharacteristicType(.bloodType)]))
                 }
-                AsyncButton("Request CyclingDistance", state: $viewState) {
+                AsyncButton("Request Cycling Distance", state: $viewState) {
                     try await healthKit.askForAuthorization(for: .init(read: [HKQuantityType(.distanceCycling)]))
                 }
             }

--- a/Tests/UITests/TestApp/HealthKitTestsView/HealthKitTestsView.swift
+++ b/Tests/UITests/TestApp/HealthKitTestsView/HealthKitTestsView.swift
@@ -20,7 +20,7 @@ struct HealthKitTestsView: View {
         case statisticsQuery = "Statistics Query"
         case characteristicsQuery = "Characteristics Query"
         case sleepSessions = "Sleep Sessions"
-        case scoredAssessments = "Scored Assessements"
+        case scoredAssessments = "Scored Assessments"
         case bulkExporter = "Bulk Exporter"
         case sourceFiltering = "Source Filtering"
         case deferredAuthorization = "Deferred Authorization"

--- a/Tests/UITests/TestApp/HealthKitTestsView/HealthKitTestsView.swift
+++ b/Tests/UITests/TestApp/HealthKitTestsView/HealthKitTestsView.swift
@@ -14,14 +14,27 @@ import SwiftUI
 
 
 struct HealthKitTestsView: View {
+    enum TestView: String, CaseIterable {
+        case collectSamples = "Collect Samples"
+        case samplesQuery = "Samples Query"
+        case statisticsQuery = "Statistics Query"
+        case characteristicsQuery = "Characteristics Query"
+        case sleepSessions = "Sleep Sessions"
+        case scoredAssessments = "Scored Assessements"
+        case bulkExporter = "Bulk Exporter"
+        case sourceFiltering = "Source Filtering"
+        case deferredAuthorization = "Deferred Authorization"
+    }
+    
     @Environment(HealthKit.self) var healthKit
     @Environment(FakeHealthStore.self) var fakeHealthStore
     
     @State private var allInitialSampleTypesAreAuthorized = false
     @State private var viewState: ViewState = .idle
+    @State private var tmp = false
     
     var body: some View {
-        Form { // swiftlint:disable:this closure_body_length
+        Form {
             Section {
                 AsyncButton("Ask for authorization", state: $viewState) {
                     try? await healthKit.askForAuthorization()
@@ -34,30 +47,31 @@ struct HealthKitTestsView: View {
                 }
             }
             Section {
-                NavigationLink("Collect Samples") {
-                    CollectSamplesTestView()
+                ForEach(TestView.allCases, id: \.self) { testView in
+                    NavigationLink(testView.rawValue, value: testView)
                 }
-                NavigationLink("Samples Query") {
-                    SamplesQueryView()
-                }
-                NavigationLink("Statistics Query") {
-                    StatisticsQueryView()
-                }
-                NavigationLink("Characteristics") {
-                    CharacteristicsView()
-                }
-                NavigationLink("Sleep Sessions") {
-                    SleepSessionsView()
-                }
-                NavigationLink("Scored Assessments") {
-                    ScoredAssessmentsView()
-                }
-                NavigationLink("Bulk Exporter") {
-                    BulkExportView()
-                }
-                NavigationLink("Source Filtering") {
-                    SourceFilteredQueryView()
-                }
+            }
+        }
+        .navigationDestination(for: TestView.self) { testView in
+            switch testView {
+            case .collectSamples:
+                CollectSamplesTestView()
+            case .samplesQuery:
+                SamplesQueryView()
+            case .statisticsQuery:
+                StatisticsQueryView()
+            case .characteristicsQuery:
+                CharacteristicsView()
+            case .sleepSessions:
+                SleepSessionsView()
+            case .scoredAssessments:
+                ScoredAssessmentsView()
+            case .bulkExporter:
+                BulkExportView()
+            case .sourceFiltering:
+                SourceFilteredQueryView()
+            case .deferredAuthorization:
+                DeferredAuthorizationTests(viewState: $viewState)
             }
         }
         .viewStateAlert(state: $viewState)

--- a/Tests/UITests/TestApp/HealthKitTestsView/HealthKitTestsView.swift
+++ b/Tests/UITests/TestApp/HealthKitTestsView/HealthKitTestsView.swift
@@ -31,7 +31,6 @@ struct HealthKitTestsView: View {
     
     @State private var allInitialSampleTypesAreAuthorized = false
     @State private var viewState: ViewState = .idle
-    @State private var tmp = false
     
     var body: some View {
         Form {

--- a/Tests/UITests/TestApp/TestAppDelegate.swift
+++ b/Tests/UITests/TestApp/TestAppDelegate.swift
@@ -14,7 +14,7 @@ import SpeziHealthKitBulkExport
 class TestAppDelegate: SpeziAppDelegate {
     override var configuration: Configuration {
         Configuration(standard: HealthKitTestAppStandard()) { // swiftlint:disable:this closure_body_length
-            HealthKit {
+            HealthKit { // swiftlint:disable:this closure_body_length
                 CollectSample(
                     .electrocardiogram,
                     start: .manual,
@@ -43,13 +43,21 @@ class TestAppDelegate: SpeziAppDelegate {
                 RequestReadAccess(
                     quantity: [.bloodOxygen],
                     category: [.sleepAnalysis],
-                    // intentionally omitting the blood type here, since we use that for testing the deferred authorization observer
-                    characteristic: [.activityMoveMode, .biologicalSex, .dateOfBirth, .fitzpatrickSkinType, .wheelchairUse],
+                    characteristic: Array {
+                        HealthKitCharacteristic.activityMoveMode
+                        HealthKitCharacteristic.biologicalSex
+                        if !ProcessInfo.processInfo.arguments.contains("--disable-blood-type-auth-request") {
+                            HealthKitCharacteristic.bloodType
+                        }
+                        HealthKitCharacteristic.dateOfBirth
+                        HealthKitCharacteristic.fitzpatrickSkinType
+                        HealthKitCharacteristic.wheelchairUse
+                    },
                     other: [SampleType.workout, SampleType.audiogram, SampleType.gad7, SampleType.phq9]
                 )
                 
                 RequestWriteAccess(
-                    quantity: [.heartRate, .bloodOxygen, .stepCount, .height, .activeEnergyBurned, .pushCount],
+                    quantity: [.heartRate, .bloodOxygen, .stepCount, .height, .activeEnergyBurned, .pushCount, .distanceCycling],
                     category: [.sleepAnalysis],
                     other: [SampleType.gad7, SampleType.phq9]
                 )

--- a/Tests/UITests/TestApp/TestAppDelegate.swift
+++ b/Tests/UITests/TestApp/TestAppDelegate.swift
@@ -38,7 +38,7 @@ class TestAppDelegate: SpeziAppDelegate {
                 CollectSample(.stairAscentSpeed, continueInBackground: true)
                 CollectSample(.stairDescentSpeed, continueInBackground: false)
                 CollectSample(.workout)
-                CollectSample(.bloodPressure, start: .automatic)
+                CollectSample(.bloodPressure, start: .automatic, continueInBackground: true)
                 
                 RequestReadAccess(
                     quantity: [.bloodOxygen],

--- a/Tests/UITests/TestApp/TestAppDelegate.swift
+++ b/Tests/UITests/TestApp/TestAppDelegate.swift
@@ -43,7 +43,8 @@ class TestAppDelegate: SpeziAppDelegate {
                 RequestReadAccess(
                     quantity: [.bloodOxygen],
                     category: [.sleepAnalysis],
-                    characteristic: [.activityMoveMode, .biologicalSex, .bloodType, .dateOfBirth, .fitzpatrickSkinType, .wheelchairUse],
+                    // intentionally omitting the blood type here, since we use that for testing the deferred authorization observer
+                    characteristic: [.activityMoveMode, .biologicalSex, .dateOfBirth, .fitzpatrickSkinType, .wheelchairUse],
                     other: [SampleType.workout, SampleType.audiogram, SampleType.gad7, SampleType.phq9]
                 )
                 

--- a/Tests/UITests/TestAppUITests/AuthorizationTests.swift
+++ b/Tests/UITests/TestAppUITests/AuthorizationTests.swift
@@ -11,9 +11,9 @@ import XCTest
 
 final class AuthorizationTests: SpeziHealthKitTests {
     @MainActor
-    func testRepeatedHealthKitAuthorization() async throws {
+    func testRepeatedHealthKitAuthorization() throws {
         let app = XCUIApplication(launchArguments: ["--collectedSamplesOnly"])
-        try await launchAndHandleInitialStuff(app, deleteAllHealthData: true)
+        try launchAndHandleInitialStuff(app, deleteAllHealthData: true)
         // Wait for button to become disabled
         let expectation = XCTNSPredicateExpectation(
             predicate: NSPredicate { _, _ in
@@ -21,7 +21,7 @@ final class AuthorizationTests: SpeziHealthKitTests {
             },
             object: .none
         )
-        await fulfillment(of: [expectation], timeout: 2)
+        wait(for: [expectation], timeout: 2)
         XCTAssert(!app.buttons["Ask for authorization"].isEnabled)
     }
 }

--- a/Tests/UITests/TestAppUITests/BulkExporterTests.swift
+++ b/Tests/UITests/TestAppUITests/BulkExporterTests.swift
@@ -74,8 +74,6 @@ final class BulkExporterTests: SpeziHealthKitTests {
         app.buttons["Start Bulk Export"].tap()
         XCTAssert(app.staticTexts["State, completed"].waitForExistence(timeout: 180))
         XCTAssertEqual(try XCTUnwrap(app.numExportedSamples) + numExportedSamplesFirstSession, try XCTUnwrap(app.numTestingSamples))
-        
-        XCTFail("uhh ohhh")
     }
     
     

--- a/Tests/UITests/TestAppUITests/BulkExporterTests.swift
+++ b/Tests/UITests/TestAppUITests/BulkExporterTests.swift
@@ -24,12 +24,13 @@ final class BulkExporterTests: SpeziHealthKitTests {
         app.buttons["Add Historical Data"].tap()
         XCTAssert(app.staticTexts["Adding Historical Samples…"].waitForExistence(timeout: 2))
         XCTAssert(app.staticTexts["Adding Historical Samples…"].waitForNonExistence(timeout: 120))
+        sleep(for: .seconds(1))
         
         XCTAssertEqual(try XCTUnwrap(app.numExportedSamples), 0)
         XCTAssertGreaterThan(try XCTUnwrap(app.numTestingSamples), 0)
         
         app.buttons["Start Bulk Export"].tap()
-        XCTAssert(app.staticTexts["Completed 8 of 27 (0 failed)"].waitForExistence(timeout: 60))
+        XCTAssert(app.staticTexts["Completed 8 of 53 (0 failed)"].waitForExistence(timeout: 60))
         app.buttons["Pause"].tap()
         sleep(for: .seconds(2))
         app.buttons["Start"].tap()
@@ -52,6 +53,7 @@ final class BulkExporterTests: SpeziHealthKitTests {
         app.buttons["Add Historical Data"].tap()
         XCTAssert(app.staticTexts["Adding Historical Samples…"].waitForExistence(timeout: 2))
         XCTAssert(app.staticTexts["Adding Historical Samples…"].waitForNonExistence(timeout: 120))
+        sleep(for: .seconds(1))
         
         XCTAssertEqual(try XCTUnwrap(app.numExportedSamples), 0)
         XCTAssertGreaterThan(try XCTUnwrap(app.numTestingSamples), 0)
@@ -87,7 +89,8 @@ final class BulkExporterTests: SpeziHealthKitTests {
         
         app.buttons["Add Historical Data"].tap()
         XCTAssert(app.staticTexts["Adding Historical Samples…"].waitForExistence(timeout: 2))
-        XCTAssert(app.staticTexts["Adding Historical Samples…"].waitForNonExistence(timeout: 60))
+        XCTAssert(app.staticTexts["Adding Historical Samples…"].waitForNonExistence(timeout: 120))
+        sleep(for: .seconds(1))
         
         XCTAssertEqual(try XCTUnwrap(app.numExportedSamples), 0)
         XCTAssertGreaterThan(try XCTUnwrap(app.numTestingSamples), 0)

--- a/Tests/UITests/TestAppUITests/BulkExporterTests.swift
+++ b/Tests/UITests/TestAppUITests/BulkExporterTests.swift
@@ -24,7 +24,7 @@ final class BulkExporterTests: SpeziHealthKitTests {
         app.buttons["Add Historical Data"].tap()
         XCTAssert(app.staticTexts["Adding Historical Samples…"].waitForExistence(timeout: 2))
         XCTAssert(app.staticTexts["Adding Historical Samples…"].waitForNonExistence(timeout: 120))
-        XCTAssert(app.staticTexts["Add Historical Data"].waitForExistence(timeout: 20))
+        XCTAssert(app.buttons["Add Historical Data"].waitForExistence(timeout: 20))
         
         XCTAssertEqual(try XCTUnwrap(app.numExportedSamples), 0)
         XCTAssertGreaterThan(try XCTUnwrap(app.numTestingSamples), 0)
@@ -53,7 +53,7 @@ final class BulkExporterTests: SpeziHealthKitTests {
         app.buttons["Add Historical Data"].tap()
         XCTAssert(app.staticTexts["Adding Historical Samples…"].waitForExistence(timeout: 2))
         XCTAssert(app.staticTexts["Adding Historical Samples…"].waitForNonExistence(timeout: 120))
-        XCTAssert(app.staticTexts["Add Historical Data"].waitForExistence(timeout: 20))
+        XCTAssert(app.buttons["Add Historical Data"].waitForExistence(timeout: 20))
         
         XCTAssertEqual(try XCTUnwrap(app.numExportedSamples), 0)
         XCTAssertGreaterThan(try XCTUnwrap(app.numTestingSamples), 0)
@@ -93,7 +93,7 @@ final class BulkExporterTests: SpeziHealthKitTests {
         app.buttons["Add Historical Data"].tap()
         XCTAssert(app.staticTexts["Adding Historical Samples…"].waitForExistence(timeout: 2))
         XCTAssert(app.staticTexts["Adding Historical Samples…"].waitForNonExistence(timeout: 120))
-        XCTAssert(app.staticTexts["Add Historical Data"].waitForExistence(timeout: 20))
+        XCTAssert(app.buttons["Add Historical Data"].waitForExistence(timeout: 20))
         
         XCTAssertEqual(try XCTUnwrap(app.numExportedSamples), 0)
         XCTAssertGreaterThan(try XCTUnwrap(app.numTestingSamples), 0)

--- a/Tests/UITests/TestAppUITests/BulkExporterTests.swift
+++ b/Tests/UITests/TestAppUITests/BulkExporterTests.swift
@@ -24,7 +24,7 @@ final class BulkExporterTests: SpeziHealthKitTests {
         app.buttons["Add Historical Data"].tap()
         XCTAssert(app.staticTexts["Adding Historical Samples…"].waitForExistence(timeout: 2))
         XCTAssert(app.staticTexts["Adding Historical Samples…"].waitForNonExistence(timeout: 120))
-        sleep(for: .seconds(1))
+        XCTAssert(app.staticTexts["Add Historical Data"].waitForExistence(timeout: 20))
         
         XCTAssertEqual(try XCTUnwrap(app.numExportedSamples), 0)
         XCTAssertGreaterThan(try XCTUnwrap(app.numTestingSamples), 0)
@@ -53,7 +53,7 @@ final class BulkExporterTests: SpeziHealthKitTests {
         app.buttons["Add Historical Data"].tap()
         XCTAssert(app.staticTexts["Adding Historical Samples…"].waitForExistence(timeout: 2))
         XCTAssert(app.staticTexts["Adding Historical Samples…"].waitForNonExistence(timeout: 120))
-        sleep(for: .seconds(1))
+        XCTAssert(app.staticTexts["Add Historical Data"].waitForExistence(timeout: 20))
         
         XCTAssertEqual(try XCTUnwrap(app.numExportedSamples), 0)
         XCTAssertGreaterThan(try XCTUnwrap(app.numTestingSamples), 0)
@@ -67,12 +67,15 @@ final class BulkExporterTests: SpeziHealthKitTests {
         
         try launchAndHandleInitialStuff(app, deleteAllHealthData: false)
         app.buttons["Bulk Exporter"].tap()
+        sleep(for: .seconds(1))
         XCTAssertEqual(try XCTUnwrap(app.numExportedSamples), 0)
         XCTAssertGreaterThan(try XCTUnwrap(app.numTestingSamples), 0)
         
         app.buttons["Start Bulk Export"].tap()
         XCTAssert(app.staticTexts["State, completed"].waitForExistence(timeout: 180))
         XCTAssertEqual(try XCTUnwrap(app.numExportedSamples) + numExportedSamplesFirstSession, try XCTUnwrap(app.numTestingSamples))
+        
+        XCTFail("uhh ohhh")
     }
     
     
@@ -90,7 +93,7 @@ final class BulkExporterTests: SpeziHealthKitTests {
         app.buttons["Add Historical Data"].tap()
         XCTAssert(app.staticTexts["Adding Historical Samples…"].waitForExistence(timeout: 2))
         XCTAssert(app.staticTexts["Adding Historical Samples…"].waitForNonExistence(timeout: 120))
-        sleep(for: .seconds(1))
+        XCTAssert(app.staticTexts["Add Historical Data"].waitForExistence(timeout: 20))
         
         XCTAssertEqual(try XCTUnwrap(app.numExportedSamples), 0)
         XCTAssertGreaterThan(try XCTUnwrap(app.numTestingSamples), 0)

--- a/Tests/UITests/TestAppUITests/BulkExporterTests.swift
+++ b/Tests/UITests/TestAppUITests/BulkExporterTests.swift
@@ -23,13 +23,13 @@ final class BulkExporterTests: SpeziHealthKitTests {
         
         app.buttons["Add Historical Data"].tap()
         XCTAssert(app.staticTexts["Adding Historical Samples…"].waitForExistence(timeout: 2))
-        XCTAssert(app.staticTexts["Adding Historical Samples…"].waitForNonExistence(timeout: 60))
+        XCTAssert(app.staticTexts["Adding Historical Samples…"].waitForNonExistence(timeout: 120))
         
         XCTAssertEqual(try XCTUnwrap(app.numExportedSamples), 0)
         XCTAssertGreaterThan(try XCTUnwrap(app.numTestingSamples), 0)
         
         app.buttons["Start Bulk Export"].tap()
-        XCTAssert(app.staticTexts["Completed 8 of 27 (0 failed)"].waitForExistence(timeout: 20))
+        XCTAssert(app.staticTexts["Completed 8 of 27 (0 failed)"].waitForExistence(timeout: 60))
         app.buttons["Pause"].tap()
         sleep(for: .seconds(2))
         app.buttons["Start"].tap()
@@ -51,7 +51,7 @@ final class BulkExporterTests: SpeziHealthKitTests {
         
         app.buttons["Add Historical Data"].tap()
         XCTAssert(app.staticTexts["Adding Historical Samples…"].waitForExistence(timeout: 2))
-        XCTAssert(app.staticTexts["Adding Historical Samples…"].waitForNonExistence(timeout: 60))
+        XCTAssert(app.staticTexts["Adding Historical Samples…"].waitForNonExistence(timeout: 120))
         
         XCTAssertEqual(try XCTUnwrap(app.numExportedSamples), 0)
         XCTAssertGreaterThan(try XCTUnwrap(app.numTestingSamples), 0)
@@ -69,7 +69,7 @@ final class BulkExporterTests: SpeziHealthKitTests {
         XCTAssertGreaterThan(try XCTUnwrap(app.numTestingSamples), 0)
         
         app.buttons["Start Bulk Export"].tap()
-        XCTAssert(app.staticTexts["State, completed"].waitForExistence(timeout: 30))
+        XCTAssert(app.staticTexts["State, completed"].waitForExistence(timeout: 180))
         XCTAssertEqual(try XCTUnwrap(app.numExportedSamples) + numExportedSamplesFirstSession, try XCTUnwrap(app.numTestingSamples))
     }
     

--- a/Tests/UITests/TestAppUITests/BulkExporterTests.swift
+++ b/Tests/UITests/TestAppUITests/BulkExporterTests.swift
@@ -12,10 +12,10 @@ import XCTest
 
 final class BulkExporterTests: SpeziHealthKitTests {
     @MainActor
-    func testBulkExport() async throws {
+    func testBulkExport() throws {
         let app = XCUIApplication(launchArguments: ["--collectedSamplesOnly"])
-        try await launchAndHandleInitialStuff(app, deleteAllHealthData: true)
-        try await Task.sleep(for: .seconds(1))
+        try launchAndHandleInitialStuff(app, deleteAllHealthData: true)
+        sleep(for: .seconds(1))
         app.buttons["Bulk Exporter"].tap()
         
         app.buttons["Request full access"].tap()
@@ -31,7 +31,7 @@ final class BulkExporterTests: SpeziHealthKitTests {
         app.buttons["Start Bulk Export"].tap()
         XCTAssert(app.staticTexts["Completed 8 of 27 (0 failed)"].waitForExistence(timeout: 20))
         app.buttons["Pause"].tap()
-        try await Task.sleep(for: .seconds(2))
+        sleep(for: .seconds(2))
         app.buttons["Start"].tap()
         XCTAssert(app.staticTexts["State, completed"].waitForExistence(timeout: 30))
         XCTAssertEqual(try XCTUnwrap(app.numExportedSamples), try XCTUnwrap(app.numTestingSamples))
@@ -39,10 +39,10 @@ final class BulkExporterTests: SpeziHealthKitTests {
     
     
     @MainActor
-    func testBulkExportReset() async throws {
+    func testBulkExportReset() throws {
         let app = XCUIApplication(launchArguments: ["--collectedSamplesOnly"])
-        try await launchAndHandleInitialStuff(app, deleteAllHealthData: true)
-        try await Task.sleep(for: .seconds(1))
+        try launchAndHandleInitialStuff(app, deleteAllHealthData: true)
+        sleep(for: .seconds(1))
         
         app.buttons["Bulk Exporter"].tap()
         
@@ -57,13 +57,13 @@ final class BulkExporterTests: SpeziHealthKitTests {
         XCTAssertGreaterThan(try XCTUnwrap(app.numTestingSamples), 0)
         
         app.buttons["Start Bulk Export"].tap()
-        try await Task.sleep(for: .seconds(7))
+        sleep(for: .seconds(7))
         app.buttons["Pause"].tap()
-        try await Task.sleep(for: .seconds(1))
+        sleep(for: .seconds(1))
         let numExportedSamplesFirstSession = try XCTUnwrap(app.numExportedSamples)
         app.terminate()
         
-        try await launchAndHandleInitialStuff(app, deleteAllHealthData: false)
+        try launchAndHandleInitialStuff(app, deleteAllHealthData: false)
         app.buttons["Bulk Exporter"].tap()
         XCTAssertEqual(try XCTUnwrap(app.numExportedSamples), 0)
         XCTAssertGreaterThan(try XCTUnwrap(app.numTestingSamples), 0)
@@ -75,10 +75,10 @@ final class BulkExporterTests: SpeziHealthKitTests {
     
     
     @MainActor
-    func testDeleteSessionRestorationInfo() async throws {
+    func testDeleteSessionRestorationInfo() throws {
         let app = XCUIApplication(launchArguments: ["--collectedSamplesOnly"])
-        try await launchAndHandleInitialStuff(app, deleteAllHealthData: true)
-        try await Task.sleep(for: .seconds(1))
+        try launchAndHandleInitialStuff(app, deleteAllHealthData: true)
+        sleep(for: .seconds(1))
         
         app.buttons["Bulk Exporter"].tap()
         
@@ -93,12 +93,12 @@ final class BulkExporterTests: SpeziHealthKitTests {
         XCTAssertGreaterThan(try XCTUnwrap(app.numTestingSamples), 0)
         
         app.buttons["Start Bulk Export"].tap()
-        try await Task.sleep(for: .seconds(7))
+        sleep(for: .seconds(7))
         app.buttons["Pause"].tap()
-        try await Task.sleep(for: .seconds(1))
+        sleep(for: .seconds(1))
         app.terminate()
         
-        try await launchAndHandleInitialStuff(app, deleteAllHealthData: false)
+        try launchAndHandleInitialStuff(app, deleteAllHealthData: false)
         app.buttons["Bulk Exporter"].tap()
         XCTAssertEqual(try XCTUnwrap(app.numExportedSamples), 0)
         XCTAssertGreaterThan(try XCTUnwrap(app.numTestingSamples), 0)

--- a/Tests/UITests/TestAppUITests/BulkExporterTests.swift
+++ b/Tests/UITests/TestAppUITests/BulkExporterTests.swift
@@ -34,7 +34,7 @@ final class BulkExporterTests: SpeziHealthKitTests {
         app.buttons["Pause"].tap()
         sleep(for: .seconds(2))
         app.buttons["Start"].tap()
-        XCTAssert(app.staticTexts["State, completed"].waitForExistence(timeout: 30))
+        XCTAssert(app.staticTexts["State, completed"].waitForExistence(timeout: 180))
         XCTAssertEqual(try XCTUnwrap(app.numExportedSamples), try XCTUnwrap(app.numTestingSamples))
     }
     

--- a/Tests/UITests/TestAppUITests/CollectSampleTests.swift
+++ b/Tests/UITests/TestAppUITests/CollectSampleTests.swift
@@ -16,66 +16,66 @@ import XCTHealthKit
 
 final class CollectSampleTests: SpeziHealthKitTests {
     @MainActor
-    func testCollectSamples() async throws {
+    func testCollectSamples() throws {
         let app = XCUIApplication(launchArguments: ["--collectedSamplesOnly"])
-        try await launchAndHandleInitialStuff(app, deleteAllHealthData: true)
+        try launchAndHandleInitialStuff(app, deleteAllHealthData: true)
         
         app.buttons["Collect Samples"].tap()
         
         // At the beginning, we expect nothing to be collected
-        try await assertCollectedSamplesSinceLaunch(in: app, [:])
+        assertCollectedSamplesSinceLaunch(in: app, [:])
         // Add a heart rate sample
-        try await addSample(.heartRate, in: app)
+        addSample(.heartRate, in: app)
         // Since the CollectSample start setting for heart rate is .manual, it stil shouldn't be there
-        try await assertCollectedSamplesSinceLaunch(in: app, [:])
+        assertCollectedSamplesSinceLaunch(in: app, [:])
         // We manually start the heart rate data collection, which should make the sample show up
         triggerDataCollection(in: app)
-        try await assertCollectedSamplesSinceLaunch(in: app, [
+        assertCollectedSamplesSinceLaunch(in: app, [
             .heartRate: 1
         ])
         
         // Add an active energy burned sample
-        try await addSample(.activeEnergyBurned, in: app)
+        addSample(.activeEnergyBurned, in: app)
         // Since we have a continuous automatic query for these, it should show up immediately.
-        try await assertCollectedSamplesSinceLaunch(in: app, [
+        assertCollectedSamplesSinceLaunch(in: app, [
             .heartRate: 1,
             .activeEnergyBurned: 1
         ])
         
         // Add a step count sample
-        try await addSample(.stepCount, in: app)
+        addSample(.stepCount, in: app)
         // These are collected via an automatic background query, and should therefore also directly show up
-        try await assertCollectedSamplesSinceLaunch(in: app, [
+        assertCollectedSamplesSinceLaunch(in: app, [
             .heartRate: 1,
             .activeEnergyBurned: 1,
             .stepCount: 1
         ])
         
         // Add a height sample. These aren't collected at all, and should never show up
-        try await addSample(.height, in: app)
-        try await assertCollectedSamplesSinceLaunch(in: app, [
+        addSample(.height, in: app)
+        assertCollectedSamplesSinceLaunch(in: app, [
             .heartRate: 1,
             .activeEnergyBurned: 1,
             .stepCount: 1
         ])
         
         // Add another active energy burned sample. As before, this should show up immediately
-        try await addSample(.activeEnergyBurned, in: app)
-        try await assertCollectedSamplesSinceLaunch(in: app, [
+        addSample(.activeEnergyBurned, in: app)
+        assertCollectedSamplesSinceLaunch(in: app, [
             .heartRate: 1,
             .activeEnergyBurned: 2,
             .stepCount: 1
         ])
         
         // i'm gonna do it again
-        try await addSample(.activeEnergyBurned, in: app)
-        try await assertCollectedSamplesSinceLaunch(in: app, [
+        addSample(.activeEnergyBurned, in: app)
+        assertCollectedSamplesSinceLaunch(in: app, [
             .heartRate: 1,
             .activeEnergyBurned: 3,
             .stepCount: 1
         ])
         
         app.buttons["Register more CollectSample instances"].tap()
-        try await Task.sleep(for: .seconds(1)) // give it some time to handle this.
+        sleep(for: .seconds(1)) // give it some time to handle this.
     }
 }

--- a/Tests/UITests/TestAppUITests/HealthKitQueryTests.swift
+++ b/Tests/UITests/TestAppUITests/HealthKitQueryTests.swift
@@ -67,7 +67,7 @@ final class HealthKitQueryTests: SpeziHealthKitTests {
         app.buttons["Characteristics Query"].tap()
         
         app.assertTableRow("Move Mode", "1")
-        app.assertTableRow("Blood Type", "O+")
+        app.assertTableRow("Blood Type", "O\\+")
         app.assertTableRow("Date of Birth", "2022-10-11T[0-9]{2}:00:00Z")
         app.assertTableRow("Biological Sex", "1")
         app.assertTableRow("Skin Type", "1")
@@ -190,8 +190,7 @@ final class HealthKitQueryTests: SpeziHealthKitTests {
         try launchAndHandleInitialStuff(app, deleteAllHealthData: true)
         app.terminate()
         
-        let healthApp = XCUIApplication.healthApp
-        try launchAndAddSamples(healthApp: healthApp, [
+        try launchAndAddSamples(healthApp: .healthApp, [
             .steps()
         ])
         

--- a/Tests/UITests/TestAppUITests/HealthKitQueryTests.swift
+++ b/Tests/UITests/TestAppUITests/HealthKitQueryTests.swift
@@ -54,9 +54,12 @@ final class HealthKitQueryTests: SpeziHealthKitTests {
         let app = XCUIApplication(launchArguments: ["--collectedSamplesOnly"])
         try launchAndHandleInitialStuff(app, deleteAllHealthData: true)
         
+        let dateOfBirthComponents = DateComponents(year: 2022, month: 10, day: 11)
+        let dateOfBirth = try XCTUnwrap(Calendar.current.date(from: dateOfBirthComponents))
+        
         try launchHealthAppAndEnterCharacteristics(.init(
             bloodType: .oPositive,
-            dateOfBirth: .init(year: 2022, month: 10, day: 11),
+            dateOfBirth: dateOfBirthComponents,
             biologicalSex: .female,
             skinType: .I,
             wheelchairUse: .no
@@ -68,7 +71,7 @@ final class HealthKitQueryTests: SpeziHealthKitTests {
         
         app.assertTableRow("Move Mode", "1")
         app.assertTableRow("Blood Type", "O\\+")
-        app.assertTableRow("Date of Birth", "2022-10-11T[0-9]{2}:00:00Z")
+        app.assertTableRow("Date of Birth", dateOfBirth.formatted(.iso8601))
         app.assertTableRow("Biological Sex", "1")
         app.assertTableRow("Skin Type", "1")
         app.assertTableRow("Wheelchair Use", "1")

--- a/Tests/UITests/TestAppUITests/HealthKitQueryTests.swift
+++ b/Tests/UITests/TestAppUITests/HealthKitQueryTests.swift
@@ -63,8 +63,8 @@ final class HealthKitQueryTests: SpeziHealthKitTests {
         ))
         
         app.activate()
-        XCTAssert(app.buttons["Characteristics"].waitForExistence(timeout: 2))
-        app.buttons["Characteristics"].tap()
+        XCTAssert(app.buttons["Characteristics Query"].waitForExistence(timeout: 2))
+        app.buttons["Characteristics Query"].tap()
         
         app.assertTableRow("Move Mode", "1")
         app.assertTableRow("Blood Type", "2")

--- a/Tests/UITests/TestAppUITests/HealthKitQueryTests.swift
+++ b/Tests/UITests/TestAppUITests/HealthKitQueryTests.swift
@@ -12,12 +12,12 @@ import XCTest
 
 final class HealthKitQueryTests: SpeziHealthKitTests {
     @MainActor
-    func testHealthKitQuery() async throws {
+    func testHealthKitQuery() throws {
         let app = XCUIApplication(launchArguments: ["--collectedSamplesOnly"])
-        try await launchAndHandleInitialStuff(app, deleteAllHealthData: true)
+        try launchAndHandleInitialStuff(app, deleteAllHealthData: true)
         
         for _ in 0..<7 {
-            try await addSample(.stepCount, in: app)
+            addSample(.stepCount, in: app)
         }
         
         XCTAssert(app.buttons["Samples Query"].wait(for: \.isHittable, toEqual: true, timeout: 2))
@@ -28,12 +28,12 @@ final class HealthKitQueryTests: SpeziHealthKitTests {
     
     
     @MainActor
-    func testHealthKitStatisticsQuery() async throws {
+    func testHealthKitStatisticsQuery() throws {
         let app = XCUIApplication(launchArguments: ["--collectedSamplesOnly"])
-        try await launchAndHandleInitialStuff(app, deleteAllHealthData: true)
+        try launchAndHandleInitialStuff(app, deleteAllHealthData: true)
         
         for _ in 0..<7 {
-            try await addSample(.stepCount, in: app)
+            addSample(.stepCount, in: app)
         }
         
         XCTAssert(app.buttons["Samples Query"].wait(for: \.isHittable, toEqual: true, timeout: 2))
@@ -50,9 +50,9 @@ final class HealthKitQueryTests: SpeziHealthKitTests {
     
     
     @MainActor
-    func testCharacteristicsQuery() async throws {
+    func testCharacteristicsQuery() throws {
         let app = XCUIApplication(launchArguments: ["--collectedSamplesOnly"])
-        try await launchAndHandleInitialStuff(app, deleteAllHealthData: true)
+        try launchAndHandleInitialStuff(app, deleteAllHealthData: true)
         
         try launchHealthAppAndEnterCharacteristics(.init(
             bloodType: .aNegative,
@@ -76,33 +76,33 @@ final class HealthKitQueryTests: SpeziHealthKitTests {
     
     
     @MainActor
-    func testScoredAssessments() async throws {
+    func testScoredAssessments() throws {
         let app = XCUIApplication(launchArguments: ["--collectedSamplesOnly"])
-        try await launchAndHandleInitialStuff(app, deleteAllHealthData: true)
+        try launchAndHandleInitialStuff(app, deleteAllHealthData: true)
         
-        try await Task.sleep(for: .seconds(0.5)) // we need to wait a little so that the permissions sheet is properly dismissed
+        sleep(for: .seconds(0.5)) // we need to wait a little so that the permissions sheet is properly dismissed
         app.buttons["Scored Assessments"].tap()
         
         XCTAssert(app.staticTexts["No GAD-7 Assessments"].waitForExistence(timeout: 2))
         XCTAssert(app.staticTexts["No PHQ-9 Assessments"].waitForExistence(timeout: 2))
         
-        func addScore(_ name: String) async throws {
+        func addScore(_ name: String) {
             let menuButton = app.navigationBars.images["plus"]
             XCTAssert(menuButton.waitForExistence(timeout: 1))
             menuButton.tap()
             let addSampleButton = app.buttons["Add Sample: \(name)"]
             XCTAssert(addSampleButton.waitForExistence(timeout: 2))
             addSampleButton.tap()
-            try await Task.sleep(for: .seconds(0.5)) // i sleep
+            sleep(for: .seconds(0.5)) // i sleep
         }
         
-        try await addScore("GAD-7")
+        addScore("GAD-7")
         XCTAssert(app.staticTexts["No GAD-7 Assessments"].waitForNonExistence(timeout: 2))
         app.assertTableRow("Date", "2025-04-25")
         app.assertTableRow("Risk", "2")
         app.assertTableRow("Answers", "2;3;0;1;1;0;2")
         
-        try await addScore("PHQ-9")
+        addScore("PHQ-9")
         XCTAssert(app.staticTexts["No PHQ-9 Assessments"].waitForNonExistence(timeout: 2))
         app.assertTableRow("Date", "2025-04-27")
         app.assertTableRow("Risk", "3")
@@ -111,14 +111,14 @@ final class HealthKitQueryTests: SpeziHealthKitTests {
     
     
     @MainActor
-    func testSleepSession() async throws {
+    func testSleepSession() throws {
         let app = XCUIApplication(launchArguments: ["--collectedSamplesOnly"])
-        try await launchAndHandleInitialStuff(app, deleteAllHealthData: true)
+        try launchAndHandleInitialStuff(app, deleteAllHealthData: true)
         
-        try await Task.sleep(for: .seconds(0.5)) // we need to wait a little so that the permissions sheet is properly dismissed
+        sleep(for: .seconds(0.5)) // we need to wait a little so that the permissions sheet is properly dismissed
         app.buttons["Sleep Sessions"].tap()
         
-        try await Task.sleep(for: .seconds(2)) // give it a bit to fetch and process the data
+        sleep(for: .seconds(2)) // give it a bit to fetch and process the data
         
         if app.staticTexts["No Sleep Data"].waitForExistence(timeout: 1) {
             app.navigationBars.buttons["Add Samples"].tap()
@@ -136,11 +136,17 @@ final class HealthKitQueryTests: SpeziHealthKitTests {
     
     
     @MainActor
-    func testSleepSession2() async throws {
+    func testSleepSession2() throws {
+        print(#function, #line)
         let app = XCUIApplication(launchArguments: ["--collectedSamplesOnly"])
-        try await launchAndHandleInitialStuff(app, deleteAllHealthData: true)
-        try await Task.sleep(for: .seconds(0.5)) // we need to wait a little so that the permissions sheet is properly dismissed
+        print(#function, #line)
+        try launchAndHandleInitialStuff(app, deleteAllHealthData: true)
+        print(#function, #line)
+        sleep(for: .seconds(0.5)) // we need to wait a little so that the permissions sheet is properly dismissed
+//        sleep(1)
+        print(#function, #line)
         app.buttons["Sleep Tests"].tap()
+        print(#function, #line)
         XCTAssert(app.staticTexts["Success"].waitForExistence(timeout: 5))
     }
     
@@ -149,35 +155,35 @@ final class HealthKitQueryTests: SpeziHealthKitTests {
     // (it'll manually add samples via the Health app, which we can't easily remove, and we don't want these
     // to mess up the other tests, which operate under the assumption that there exist no such samples).
     @MainActor
-    func testXXXXXSourceFiltering() async throws {
+    func testXXXXXSourceFiltering() throws {
         throw XCTSkip()
         let app = XCUIApplication(launchArguments: ["--collectedSamplesOnly"])
-        try await launchAndHandleInitialStuff(app, deleteAllHealthData: true)
+        try launchAndHandleInitialStuff(app, deleteAllHealthData: true)
         app.terminate()
         
         let healthApp = XCUIApplication.healthApp
         healthApp.launch()
         self.handleHealthAppOnboardingIfNecessary(healthApp)
-        try await Task.sleep(for: .seconds(1))
+        sleep(for: .seconds(1))
         try launchAndAddSamples(healthApp: healthApp, [
             .steps()
         ])
         
-        try await launchAndHandleInitialStuff(app, deleteAllHealthData: false)
-        try await Task.sleep(for: .seconds(0.5)) // we need to wait a little so that the permissions sheet is properly dismissed
+        try launchAndHandleInitialStuff(app, deleteAllHealthData: false)
+        sleep(for: .seconds(0.5)) // we need to wait a little so that the permissions sheet is properly dismissed
         
         app.buttons["Source Filtering"].tap()
-        try await Task.sleep(for: .seconds(2))
+        sleep(for: .seconds(2))
         XCTAssert(app.staticTexts["Sample Counts Add Up, true"].waitForExistence(timeout: 1))
         XCTAssert(app.staticTexts["# All Samples, 1"].waitForExistence(timeout: 1))
         XCTAssert(app.staticTexts["# Our Samples"].waitForNonExistence(timeout: 1))
         XCTAssert(app.staticTexts["# Health.app Samples, 1"].waitForExistence(timeout: 1))
         
         app.navigationBars.buttons["HealthKit"].tap()
-        try await addSample(.stepCount, in: app)
+        addSample(.stepCount, in: app)
         
         app.buttons["Source Filtering"].tap()
-        try await Task.sleep(for: .seconds(2))
+        sleep(for: .seconds(2))
         XCTAssert(app.staticTexts["Sample Counts Add Up, true"].waitForExistence(timeout: 1))
         XCTAssert(app.staticTexts["# All Samples, 2"].waitForExistence(timeout: 1))
         XCTAssert(app.staticTexts["# Our Samples, 1"].waitForExistence(timeout: 1))

--- a/Tests/UITests/TestAppUITests/HealthKitQueryTests.swift
+++ b/Tests/UITests/TestAppUITests/HealthKitQueryTests.swift
@@ -140,16 +140,10 @@ final class HealthKitQueryTests: SpeziHealthKitTests {
     
     @MainActor
     func testSleepSession2() throws {
-        print(#function, #line)
         let app = XCUIApplication(launchArguments: ["--collectedSamplesOnly"])
-        print(#function, #line)
         try launchAndHandleInitialStuff(app, deleteAllHealthData: true)
-        print(#function, #line)
         sleep(for: .seconds(0.5)) // we need to wait a little so that the permissions sheet is properly dismissed
-//        sleep(1)
-        print(#function, #line)
         app.buttons["Sleep Tests"].tap()
-        print(#function, #line)
         XCTAssert(app.staticTexts["Success"].waitForExistence(timeout: 5))
     }
     

--- a/Tests/UITests/TestAppUITests/HealthKitQueryTests.swift
+++ b/Tests/UITests/TestAppUITests/HealthKitQueryTests.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import XCTest
+import XCTHealthKit
 
 
 final class HealthKitQueryTests: SpeziHealthKitTests {
@@ -186,6 +187,12 @@ final class HealthKitQueryTests: SpeziHealthKitTests {
         let app = XCUIApplication(launchArguments: ["--collectedSamplesOnly"])
         try launchAndHandleInitialStuff(app, deleteAllHealthData: true)
         app.terminate()
+        
+        let healthApp = XCUIApplication.healthApp
+        healthApp.launch()
+        if healthApp.staticTexts["Health Details"].waitForExistence(timeout: 2) {
+            healthApp.buttons["Done"].tap()
+        }
         
         try launchAndAddSamples(healthApp: .healthApp, [
             .steps()

--- a/Tests/UITests/TestAppUITests/SpeziHealthKitTests.swift
+++ b/Tests/UITests/TestAppUITests/SpeziHealthKitTests.swift
@@ -30,7 +30,7 @@ class SpeziHealthKitTests: XCTestCase {
     }
     
     @MainActor
-    func launchAndHandleInitialStuff(_ app: XCUIApplication, deleteAllHealthData: Bool) async throws {
+    func launchAndHandleInitialStuff(_ app: XCUIApplication, deleteAllHealthData: Bool) throws {
         app.launch()
         if app.alerts["“TestApp” Would Like to Send You Notifications"].waitForExistence(timeout: 5) {
             app.alerts["“TestApp” Would Like to Send You Notifications"].buttons["Allow"].tap()
@@ -42,19 +42,19 @@ class SpeziHealthKitTests: XCTestCase {
             try app.handleHealthKitAuthorization()
         }
         if deleteAllHealthData {
-            try await app.deleteAllHealthData()
+            try app.deleteAllHealthData()
         }
     }
     
     @MainActor
-    func addSample(_ sampleType: SampleType<HKQuantitySample>, in app: XCUIApplication) async throws {
+    func addSample(_ sampleType: SampleType<HKQuantitySample>, in app: XCUIApplication) {
         let menuButton = app.navigationBars.images["ellipsis.circle"]
         XCTAssert(menuButton.waitForExistence(timeout: 1))
         menuButton.tap()
         let addSampleButton = app.buttons["Add Sample: \(sampleType.displayTitle)"]
         XCTAssert(addSampleButton.waitForExistence(timeout: 2))
         addSampleButton.tap()
-        try await Task.sleep(for: .seconds(0.5)) // i sleep
+        sleep(for: .seconds(0.5)) // i sleep
     }
     
     
@@ -77,10 +77,10 @@ extension SpeziHealthKitTests {
         _ expectedNumSamplesBySampleType: NumSamplesByType,
         file: StaticString = #filePath,
         line: UInt = #line
-    ) async throws {
+    ) {
         let expected = Dictionary(uniqueKeysWithValues: expectedNumSamplesBySampleType.map { ($0.hkSampleType.identifier, $1) })
         @MainActor
-        func imp(try: Int) async throws {
+        func imp(try: Int) {
             // swiftlint:disable:next empty_count
             let staticTexts = app.staticTexts.count > 0
                 ? app.staticTexts.allElementsBoundByIndex.compactMap { $0.exists ? $0.label : nil }
@@ -90,8 +90,8 @@ extension SpeziHealthKitTests {
                 return
             }
             guard staticTexts.count > 0 else { // swiftlint:disable:this empty_count
-                try await Task.sleep(for: .seconds(2))
-                try await imp(try: `try` - 1)
+                sleep(for: .seconds(2))
+                imp(try: `try` - 1)
                 return
             }
             let actual: [String: Int] = Dictionary(uniqueKeysWithValues: staticTexts.compactMap { text in
@@ -104,14 +104,14 @@ extension SpeziHealthKitTests {
             })
             if expected != actual, `try` > 1 {
                 // try again
-                try await Task.sleep(for: .seconds(2))
-                try await imp(try: `try` - 1)
+                sleep(for: .seconds(2))
+                imp(try: `try` - 1)
                 return
             } else {
                 XCTAssertEqual(actual, expected, file: file, line: line)
             }
         }
-        try await imp(try: 5)
+        imp(try: 5)
     }
 }
 
@@ -133,7 +133,7 @@ extension XCUIApplication {
     }
     
     @MainActor
-    func deleteAllHealthData() async throws {
+    func deleteAllHealthData() throws {
         #if !targetEnvironment(simulator)
         let msg = "Refusing to delete HealthData on a non-simulator device"
         XCTFail(msg)
@@ -145,7 +145,12 @@ extension XCUIApplication {
         let button = self.buttons["Delete Test Data from HealthKit"]
         XCTAssert(button.waitForExistence(timeout: 2))
         button.tap()
-        try await Task.sleep(for: .seconds(0.5))
+        sleep(for: .seconds(0.5))
         #endif
     }
+}
+
+
+func sleep(for duration: Duration) {
+    usleep(UInt32(duration.timeInterval * 1000000))
 }

--- a/Tests/UITests/TestAppUITests/SpeziHealthKitTests.swift
+++ b/Tests/UITests/TestAppUITests/SpeziHealthKitTests.swift
@@ -30,14 +30,17 @@ class SpeziHealthKitTests: XCTestCase {
     }
     
     @MainActor
-    func launchAndHandleInitialStuff(_ app: XCUIApplication, deleteAllHealthData: Bool) throws {
+    func launchAndHandleInitialStuff(
+        _ app: XCUIApplication,
+        askForAuthorization: Bool = true, // swiftlint:disable:this function_default_parameter_at_end
+        deleteAllHealthData: Bool
+    ) throws {
         app.launch()
         if app.alerts["“TestApp” Would Like to Send You Notifications"].waitForExistence(timeout: 5) {
             app.alerts["“TestApp” Would Like to Send You Notifications"].buttons["Allow"].tap()
         }
-        
         XCTAssert(app.buttons["Ask for authorization"].waitForExistence(timeout: 3))
-        if app.buttons["Ask for authorization"].isEnabled {
+        if askForAuthorization, app.buttons["Ask for authorization"].isEnabled {
             app.buttons["Ask for authorization"].tap()
             try app.handleHealthKitAuthorization()
         }

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -637,7 +637,7 @@
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziViews.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.10.1;
+				minimumVersion = 1.12.0;
 			};
 		};
 		8042D7962D3D5B8F00807498 /* XCRemoteSwiftPackageReference "XCTestExtensions" */ = {


### PR DESCRIPTION
# authorization observation mechanism; other small changes

## :recycle: Current situation & Problem
The SpeziHealthKitUI target implements several property wrappers which allow querying HealthKit data within SwiftUI views.
These property wrappers return nil/empty results if the user hasn't granted the application read access to the data type being queried.
Currently, these property wrappers will continue to return nil/empty results if the user grants access while a query initiated by the property wrapper is active.

This PR fixes this, by adding an API for observing authorization events. This API allows the property wrappers to update/reload themselves in response to changes to their underlying sample types' authorization status.
The exact way this is handled isn't perfect: we trigger a reload of the query property wrapper every time the property wrapper's sample type's auth status changes, i.e. even if the user denies us access. This is required since we can't actually determine if we were granted access when requesting read permissions.

The new authorization event observation API is currently internal (it consists of two parts: a function on the `HealthKit` module which returns an `AsyncStream`, and a utility property wrapper for integrating observations using this stream into view lifecycles). The first part (the function) is hidden behind a `@_spi(APISupport)`, and the property wrapper is internal. We might want to consider making these public at some point in the future.

Additionally, this PR also fixes several small bugs.


## :gear: Release Notes
- The `@HealthKitQuery`, `@HealthKitStatisticsQuery`, and `@HealthKitCharacteristicsQuery` property wrappers now auto-update in response to the user granting access to the queried-for sample type. (Previously, if access hadn't been granted before the query was initiated, the results would've stayed empty.)
- Backgrund data collection via `CollectSample` now works properly for the `bloodPressure` sample type.

## :books: Documentation
The new API itself is documented. There are no changes to the public docs, since this behaviour is how it should be expected to behave. If anything, we should've documented in the past that it wasn't behaving like this.


## :white_check_mark: Testing
we have a UI test that verifies the deferred authorization, and a unit test for the bulk export batch sizing changes


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
