### PR TITLE
rework `dateOfBirth` characteristic API

### DIFF
--- a/Tests/UITests/TestApp/HealthKitTestsView/CharacteristicsView.swift
+++ b/Tests/UITests/TestApp/HealthKitTestsView/CharacteristicsView.swift
@@ -23,6 +23,9 @@ struct CharacteristicsView: View {
     @HealthKitCharacteristicQuery(.dateOfBirth)
     private var dateOfBirth
     
+    @HealthKitCharacteristicQuery(.dateOfBirthComponents)
+    private var dateOfBirthComponents
+    
     @HealthKitCharacteristicQuery(.biologicalSex)
     private var biologicalSex
     
@@ -37,6 +40,7 @@ struct CharacteristicsView: View {
             makeRow("Move Mode", value: moveMode)
             LabeledContent("Blood Type", value: bloodType?.displayTitle.localizedString() ?? "n/a")
             LabeledContent("Date of Birth", value: dateOfBirth?.formatted(.iso8601) ?? "n/a")
+            LabeledContent("Date of Birth Components", value: dateOfBirthComponents?.description ?? "n/a")
             makeRow("Biological Sex", value: biologicalSex)
             makeRow("Skin Type", value: skinType)
             makeRow("Wheelchair Use", value: wheelchairUse)

--- a/Tests/UITests/TestAppUITests/HealthKitQueryTests.swift
+++ b/Tests/UITests/TestAppUITests/HealthKitQueryTests.swift
@@ -55,7 +55,13 @@ final class HealthKitQueryTests: SpeziHealthKitTests {
         let app = XCUIApplication(launchArguments: ["--collectedSamplesOnly"])
         try launchAndHandleInitialStuff(app, deleteAllHealthData: true)
         
-        let dateOfBirthComponents = DateComponents(year: 2022, month: 10, day: 11)
+        let dateOfBirthComponents = DateComponents(
+            calendar: .init(identifier: .gregorian),
+            era: 1,
+            year: 2022,
+            month: 10,
+            day: 11
+        )
         let dateOfBirth = try XCTUnwrap(Calendar.current.date(from: dateOfBirthComponents))
         
         try launchHealthAppAndEnterCharacteristics(.init(
@@ -71,8 +77,9 @@ final class HealthKitQueryTests: SpeziHealthKitTests {
         app.buttons["Characteristics Query"].tap()
         
         app.assertTableRow("Move Mode", "1")
-        app.assertTableRow("Blood Type", "O\\+")
+        app.assertTableRow("Blood Type", "O+")
         app.assertTableRow("Date of Birth", dateOfBirth.formatted(.iso8601))
+        app.assertTableRow("Date of Birth Components", dateOfBirthComponents.description)
         app.assertTableRow("Biological Sex", "1")
         app.assertTableRow("Skin Type", "1")
         app.assertTableRow("Wheelchair Use", "1")
@@ -170,7 +177,7 @@ final class HealthKitQueryTests: SpeziHealthKitTests {
         
         app.buttons["Request Blood Type"].tap()
         try app.handleHealthKitAuthorization()
-        app.assertTableRow("Blood Type", "O\\+") // we need to escape the `+` since this is interpreted as a (NSPredicate-compatible) regex pattern.
+        app.assertTableRow("Blood Type", "O+")
         
         app.buttons["Request Cycling Distance"].tap()
         try app.handleHealthKitAuthorization()

--- a/Tests/UITests/TestAppUITests/SpeziHealthKitTests.swift
+++ b/Tests/UITests/TestAppUITests/SpeziHealthKitTests.swift
@@ -125,8 +125,8 @@ extension XCUIApplication {
         self.launchArguments.append(contentsOf: launchArguments)
     }
     
-    func assertTableRow(_ title: String, _ pattern: String, file: StaticString = #filePath, line: UInt = #line) {
-        let predicate = NSPredicate(format: "label MATCHES %@", "\(title).*\(pattern)")
+    func assertTableRow(_ title: String, _ value: String, file: StaticString = #filePath, line: UInt = #line) {
+        let predicate = NSPredicate(format: "label = %@", "\(title), \(value)")
         XCTAssert(
             self.staticTexts.matching(predicate).element.waitForExistence(timeout: 2),
             "Unable to find element '\(predicate)'",


### PR DESCRIPTION
# rework `dateOfBirth` characteristic API

## :recycle: Current situation & Problem
reworks the `dateOfBirth` characteristic API to a) produce correct values, and b) also expose the underlying `DateComponents`.
see #60 for a full explanation.


## :gear: Release Notes
- `@HealthKitCharacteristicQuery(.dateOfBirth)` now returns `Date`s that are always correctly interpreted relative to the time zone in which the date of birth was saved into HealthKit
- added `@HealthKitCharacteristicQuery(.dateOfBirthComponents)`, which returns the "raw" `DateComponents` for the date of birth, as stored in HealthKit


## :books: Documentation
yes


## :white_check_mark: Testing
yes


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
