### PR TITLE
Extend HealthKit Statistics Queries

### DIFF
--- a/Sources/SpeziHealthKit/Queries/HealthKitStatisticsQuery.swift
+++ b/Sources/SpeziHealthKit/Queries/HealthKitStatisticsQuery.swift
@@ -1,0 +1,336 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import HealthKit
+import SpeziFoundation
+
+extension HealthKit {
+    public enum CumulativeAggregationOption: Hashable {
+        case sum
+        
+        fileprivate var hkStatisticsOption: HKStatisticsOptions {
+            switch self {
+            case .sum:
+                return .cumulativeSum
+            }
+        }
+    }
+    
+    public enum DiscreteAggregationOption: Hashable {
+        case average, min, max
+        
+        fileprivate var hkStatisticsOption: HKStatisticsOptions {
+            switch self {
+            case .average:
+                return .discreteAverage
+            case .min:
+                return .discreteMin
+            case .max:
+                return .discreteMax
+            }
+        }
+    }
+    
+    public struct AggregationInterval: Hashable, Sendable {
+        public static let hour = Self(.init(hour: 1))
+        public static let day = Self(.init(day: 1))
+        public static let week = Self(.init(day: 7))
+        public static let month = Self(.init(month: 1))
+        public static let year = Self(.init(year: 1))
+        
+        /// The components defining the interval.
+        /// See [here](https://developer.apple.com/documentation/healthkit/queries/executing_statistics_collection_queries) for some more documentation.
+        public let intervalComponents: DateComponents
+        
+        public init(_ components: DateComponents) {
+            self.intervalComponents = components
+        }
+    }
+}
+
+extension HealthKit {
+    private func statisticsQuery(
+        _ sampleType: SampleType<HKQuantitySample>,
+        rawOptions options: HKStatisticsOptions,
+        aggInterval: HealthKit.AggregationInterval,
+        timeRange: HealthKitQueryTimeRange,
+        source sourceFilter: SourceFilter = .any,
+        filterPredicate: NSPredicate? = nil
+    ) async throws -> [HKStatistics] {
+        let basePredicate = NSCompoundPredicate(
+            andPredicateWithSubpredicates: [timeRange.predicate, filterPredicate].compactMap(\.self)
+        )
+        let sourcePredicate = try await sourcePredicate(
+            for: sourceFilter,
+            predicate: sampleType._makeSamplePredicate(filter: basePredicate)
+        )
+        let queryDescriptor = HKStatisticsCollectionQueryDescriptor(
+            predicate: sampleType._makeSamplePredicate(
+                filter: NSCompoundPredicate(andPredicateWithSubpredicates: [basePredicate, sourcePredicate].compactMap(\.self))
+            ),
+            options: options,
+            anchorDate: timeRange.range.lowerBound,
+            intervalComponents: aggInterval.intervalComponents
+        )
+        
+        return try await queryDescriptor.result(for: healthStore).statistics()
+    }
+    
+    /// Performs a one-off statistical query of HealthKit data, using cumulative aggregations.
+    ///
+    /// Use this function to perform a single HealthKit statistics query
+    ///
+    /// - Parameters:
+    ///   - sampleType: The ``SampleType`` you want to fetch statistics for.
+    ///   - options: The set of cumulative aggregation options to use (e.g., ``HealthKit/CumulativeAggregationOption/sum``).
+    ///   - aggInterval: The interval over which the results should be aggregated (e.g., `.day`, `.week`).
+    ///   - timeRange: The time range you want to fetch statistics for.
+    ///   - sourceFilter: Allows filtering based on the samples' `HKSource`. Defaults to ``HealthKit/SourceFilter/any``.
+    ///   - filterPredicate: Optional refining predicate that allows you to further filter which samples should be included.
+    public func statisticsQuery(
+        _ sampleType: SampleType<HKQuantitySample>,
+        aggregatedBy options: Set<HealthKit.CumulativeAggregationOption>,
+        over aggInterval: HealthKit.AggregationInterval,
+        timeRange: HealthKitQueryTimeRange,
+        source sourceFilter: SourceFilter = .any,
+        filterPredicate: NSPredicate? = nil
+    ) async throws -> [HKStatistics] {
+        try await statisticsQuery(
+            sampleType,
+            rawOptions: options.reduce(into: [.mostRecent], { partialResult, option in
+                switch option {
+                case .sum:
+                    partialResult.formUnion(.cumulativeSum)
+                }
+            }),
+            aggInterval: aggInterval,
+            timeRange: timeRange,
+            source: sourceFilter,
+            filterPredicate: filterPredicate
+        )
+    }
+    
+    /// Performs a one-off statistical query of HealthKit data, using discrete aggregations.
+    ///
+    /// Use this function to perform a single HealthKit statistics query
+    ///
+    /// - Parameters:
+    ///   - sampleType: The ``SampleType`` you want to fetch statistics for.
+    ///   - options: The set of cumulative aggregation options to use (e.g., ``HealthKit/CumulativeAggregationOption/sum``).
+    ///   - aggInterval: The interval over which the results should be aggregated (e.g., `.day`, `.week`).
+    ///   - timeRange: The time range you want to fetch statistics for.
+    ///   - sourceFilter: Allows filtering based on the samples' `HKSource`. Defaults to ``HealthKit/SourceFilter/any``.
+    ///   - filterPredicate: Optional refining predicate that allows you to further filter which samples should be included.
+    public func statisticsQuery(
+        _ sampleType: SampleType<HKQuantitySample>,
+        aggregatedBy options: Set<HealthKit.DiscreteAggregationOption>,
+        over aggInterval: HealthKit.AggregationInterval,
+        timeRange: HealthKitQueryTimeRange,
+        source sourceFilter: SourceFilter = .any,
+        filterPredicate: NSPredicate? = nil
+    ) async throws -> [HKStatistics] {
+        try await statisticsQuery(
+            sampleType,
+            rawOptions: options.reduce(into: [.mostRecent], { partialResult, option in
+                switch option {
+                case .average:
+                    partialResult.formUnion(.discreteAverage)
+                case .min:
+                    partialResult.formUnion(.discreteMin)
+                case .max:
+                    partialResult.formUnion(.discreteMax)
+                }
+            }),
+            aggInterval: aggInterval,
+            timeRange: timeRange,
+            source: sourceFilter,
+            filterPredicate: filterPredicate
+        )
+    }
+}
+
+
+extension HealthKit {
+    /// Performs a long-running query of HealthKit data using statistical aggregations.
+    ///
+    /// Use this function to run a continuous, long-running HealthKit statistics query.
+    /// This function returns an `AsyncSequence`, which will emit new elements whenever HealthKit informs us about changes to the database.
+    ///
+    /// - parameter sampleType: The ``SampleType`` that should be queried for.
+    /// - parameter options: The aggregation options used to compute statistics, such as `.cumulativeSum` or `.discreteAverage`.
+    /// - parameter aggInterval: The interval over which the statistics should be aggregated (e.g., `.day`, `.week`).
+    /// - parameter timeRange: The time range for which the query should return results.
+    /// - parameter filterPredicate: Optional refining predicate that allows you to filter which samples should be included.
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, *)
+    public func continuousStatisticsQuery(
+        _ sampleType: SampleType<HKQuantitySample>,
+        options: HKStatisticsOptions,
+        aggInterval: HealthKit.AggregationInterval,
+        timeRange: HealthKitQueryTimeRange,
+        filterPredicate: NSPredicate?
+    ) throws -> some AsyncSequence<[HKStatistics], any Error> {
+        try continuousStatisticsQueryImp(
+            sampleType,
+            options: options,
+            aggInterval: aggInterval,
+            timeRange: timeRange,
+            filterPredicate: filterPredicate
+        )
+    }
+    
+    
+    /// Performs a long-running query of HealthKit data using statistical aggregations.
+    ///
+    /// Use this function to run a continuous, long-running HealthKit statistics query.
+    /// This function returns an `AsyncSequence`, which will emit new elements whenever HealthKit informs us about changes to the database.
+    ///
+    /// - parameter sampleType: The ``SampleType`` that should be queried for.
+    /// - parameter options: The aggregation options used to compute statistics, such as `.cumulativeSum` or `.discreteAverage`.
+    /// - parameter aggInterval: The interval over which the statistics should be aggregated (e.g., `.day`, `.week`).
+    /// - parameter timeRange: The time range for which the query should return results.
+    /// - parameter sourceFilter: Allows filtering based on the samples' `HKSource`.
+    /// - parameter filterPredicate: Optional refining predicate that allows you to filter which samples should be included.
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, *)
+    public func continuousStatisticsQuery( // swiftlint:disable:this function_parameter_count
+        _ sampleType: SampleType<HKQuantitySample>,
+        options: HKStatisticsOptions,
+        aggInterval: HealthKit.AggregationInterval,
+        timeRange: HealthKitQueryTimeRange,
+        source sourceFilter: SourceFilter,
+        filterPredicate: NSPredicate?
+    ) async throws -> some AsyncSequence<[HKStatistics], any Error> {
+        try await continuousStatisticsQueryImp(
+            sampleType,
+            options: options,
+            aggInterval: aggInterval,
+            timeRange: timeRange,
+            source: sourceFilter,
+            filterPredicate: filterPredicate
+        )
+    }
+    
+    /// Performs a long-running query of HealthKit data using statistical aggregations.
+    ///
+    /// Use this function to run a continuous, long-running HealthKit statistics query.
+    /// This function returns an `AsyncSequence`, which will emit new elements whenever HealthKit informs us about changes to the database.
+    ///
+    ///
+    /// - parameter sampleType: The ``SampleType`` that should be queried for.
+    /// - parameter options: The aggregation options used to compute statistics, such as `.cumulativeSum` or `.discreteAverage`.
+    /// - parameter aggInterval: The interval over which the statistics should be aggregated (e.g., `.day`, `.week`).
+    /// - parameter timeRange: The time range for which the query should return results.
+    /// - parameter filterPredicate: Optional refining predicate that allows you to filter which samples should be included.
+    @available(iOS, deprecated: 18.0)
+    @available(macOS, deprecated: 15.0)
+    @available(watchOS, deprecated: 11.0)
+    @_disfavoredOverload
+    public func continuousStatisticsQuery(
+        _ sampleType: SampleType<HKQuantitySample>,
+        options: HKStatisticsOptions,
+        aggInterval: HealthKit.AggregationInterval,
+        timeRange: HealthKitQueryTimeRange,
+        filterPredicate: NSPredicate?
+    ) throws -> AsyncMapSequence<HKStatisticsCollectionQueryDescriptor.Results, [HKStatistics]> {
+        try continuousStatisticsQueryImp(
+            sampleType,
+            options: options,
+            aggInterval: aggInterval,
+            timeRange: timeRange,
+            filterPredicate: filterPredicate
+        )
+    }
+    
+    /// Performs a long-running query of HealthKit data using statistical aggregations.
+    ///
+    /// Use this function to run a continuous, long-running HealthKit statistics query.
+    /// This function returns an `AsyncSequence`, which will emit new elements whenever HealthKit informs us about changes to the database.
+    ///
+    /// - parameter sampleType: The ``SampleType`` that should be queried for.
+    /// - parameter options: The aggregation options used to compute statistics, such as `.cumulativeSum` or `.discreteAverage`.
+    /// - parameter aggInterval: The interval over which the statistics should be aggregated (e.g., `.day`, `.week`).
+    /// - parameter timeRange: The time range for which the query should return results.
+    /// - parameter sourceFilter: Allows filtering based on the samples' `HKSource`.
+    /// - parameter filterPredicate: Optional refining predicate that allows you to filter which samples should be included.
+    @available(iOS, deprecated: 18.0)
+    @available(macOS, deprecated: 15.0)
+    @available(watchOS, deprecated: 11.0)
+    @_disfavoredOverload
+    public func continuousStatisticsQuery( // swiftlint:disable:this function_parameter_count
+        _ sampleType: SampleType<HKQuantitySample>,
+        options: HKStatisticsOptions,
+        aggInterval: HealthKit.AggregationInterval,
+        timeRange: HealthKitQueryTimeRange,
+        source sourceFilter: SourceFilter,
+        filterPredicate: NSPredicate?
+    ) async throws -> AsyncMapSequence<HKStatisticsCollectionQueryDescriptor.Results, [HKStatistics]> {
+        try await continuousStatisticsQueryImp(
+            sampleType,
+            options: options,
+            aggInterval: aggInterval,
+            timeRange: timeRange,
+            source: sourceFilter,
+            filterPredicate: filterPredicate
+        )
+    }
+    
+    private func continuousStatisticsQueryImp( // swiftlint:disable:this function_parameter_count
+        _ sampleType: SampleType<HKQuantitySample>,
+        options: HKStatisticsOptions,
+        aggInterval: HealthKit.AggregationInterval,
+        timeRange: HealthKitQueryTimeRange,
+        source sourceFilter: SourceFilter,
+        filterPredicate: NSPredicate?
+    ) async throws -> AsyncMapSequence<HKStatisticsCollectionQueryDescriptor.Results, [HKStatistics]> {
+        let basePredicate = NSCompoundPredicate(
+            andPredicateWithSubpredicates: [timeRange.predicate, filterPredicate].compactMap(\.self)
+        )
+        let sourcePredicate = try await sourcePredicate(
+            for: sourceFilter,
+            predicate: sampleType._makeSamplePredicate(filter: basePredicate)
+        )
+        let queryDescriptor = HKStatisticsCollectionQueryDescriptor(
+            predicate: sampleType._makeSamplePredicate(
+                filter: NSCompoundPredicate(andPredicateWithSubpredicates: [basePredicate, sourcePredicate].compactMap(\.self))
+            ),
+            options: options,
+            anchorDate: timeRange.range.lowerBound,
+            intervalComponents: aggInterval.intervalComponents
+        )
+        let results = try catchingNSException {
+            queryDescriptor.results(for: healthStore)
+        }
+        
+        return results.map { $0.statisticsCollection.statistics() }
+    }
+    
+    private func continuousStatisticsQueryImp(
+        _ sampleType: SampleType<HKQuantitySample>,
+        options: HKStatisticsOptions,
+        aggInterval: HealthKit.AggregationInterval,
+        timeRange: HealthKitQueryTimeRange,
+        filterPredicate: NSPredicate?
+    ) throws -> AsyncMapSequence<HKStatisticsCollectionQueryDescriptor.Results, [HKStatistics]> {
+        let basePredicate = NSCompoundPredicate(
+            andPredicateWithSubpredicates: [timeRange.predicate, filterPredicate].compactMap(\.self)
+        )
+        let queryDescriptor = HKStatisticsCollectionQueryDescriptor(
+            predicate: sampleType._makeSamplePredicate(
+                filter: NSCompoundPredicate(andPredicateWithSubpredicates: [basePredicate].compactMap(\.self))
+            ),
+            options: options,
+            anchorDate: timeRange.range.lowerBound,
+            intervalComponents: aggInterval.intervalComponents
+        )
+        let results = try catchingNSException {
+            queryDescriptor.results(for: healthStore)
+        }
+        
+        return results.map { $0.statisticsCollection.statistics() }
+    }
+}

--- a/Sources/SpeziHealthKitUI/Queries/HealthKitStatisticsQuery.swift
+++ b/Sources/SpeziHealthKitUI/Queries/HealthKitStatisticsQuery.swift
@@ -45,50 +45,6 @@ import SwiftUI
 ///     If this is a likely scenario for your app, use a ``HealthKitQuery`` without a `SourceFilter` and then perform manual filtering on the resulting samples.
 @propertyWrapper @MainActor
 public struct HealthKitStatisticsQuery: DynamicProperty { // swiftlint:disable:this file_types_order
-    public enum CumulativeAggregationOption: Hashable {
-        case sum
-        
-        fileprivate var hkStatisticsOption: HKStatisticsOptions {
-            switch self {
-            case .sum:
-                return .cumulativeSum
-            }
-        }
-    }
-    
-    public enum DiscreteAggregationOption: Hashable {
-        case average, min, max
-        
-        fileprivate var hkStatisticsOption: HKStatisticsOptions {
-            switch self {
-            case .average:
-                return .discreteAverage
-            case .min:
-                return .discreteMin
-            case .max:
-                return .discreteMax
-            }
-        }
-    }
-    
-    
-    public struct AggregationInterval: Hashable, Sendable {
-        public static let hour = Self(.init(hour: 1))
-        public static let day = Self(.init(day: 1))
-        public static let week = Self(.init(day: 7))
-        public static let month = Self(.init(month: 1))
-        public static let year = Self(.init(year: 1))
-        
-        /// The components defining the interval.
-        /// See [here](https://developer.apple.com/documentation/healthkit/queries/executing_statistics_collection_queries) for some more documentation.
-        public let intervalComponents: DateComponents
-        
-        public init(_ components: DateComponents) {
-            self.intervalComponents = components
-        }
-    }
-    
-    
     @Environment(HealthKit.self) private var healthKit
     
     @State private var results = StatisticsQueryResults()
@@ -114,7 +70,7 @@ public struct HealthKitStatisticsQuery: DynamicProperty { // swiftlint:disable:t
     private init(
         _ sampleType: SampleType<HKQuantitySample>,
         rawOptions options: HKStatisticsOptions,
-        aggInterval: AggregationInterval,
+        aggInterval: HealthKit.AggregationInterval,
         timeRange: HealthKitQueryTimeRange,
         sourceFilter: HealthKit.SourceFilter,
         filter filterPredicate: NSPredicate?
@@ -149,15 +105,20 @@ extension HealthKitStatisticsQuery { // swiftlint:disable:this file_types_order
     /// Create a new statistics query.
     public init(
         _ sampleType: SampleType<HKQuantitySample>,
-        aggregatedBy options: Set<CumulativeAggregationOption>,
-        over aggInterval: AggregationInterval,
+        aggregatedBy options: Set<HealthKit.CumulativeAggregationOption>,
+        over aggInterval: HealthKit.AggregationInterval,
         timeRange: HealthKitQueryTimeRange,
         source sourceFilter: HealthKit.SourceFilter = .any,
         filter filterPredicate: NSPredicate? = nil
     ) {
         self.init(
             sampleType,
-            rawOptions: options.reduce(into: [.mostRecent], { $0.formUnion($1.hkStatisticsOption) }),
+            rawOptions: options.reduce(into: [.mostRecent], { partialResult, option in
+                switch option {
+                case .sum:
+                    partialResult.formUnion(.cumulativeSum)
+                }
+            }),
             aggInterval: aggInterval,
             timeRange: timeRange,
             sourceFilter: sourceFilter,
@@ -168,15 +129,24 @@ extension HealthKitStatisticsQuery { // swiftlint:disable:this file_types_order
     /// Create a new statistics query.
     public init(
         _ sampleType: SampleType<HKQuantitySample>,
-        aggregatedBy options: Set<DiscreteAggregationOption>,
-        over aggInterval: AggregationInterval,
+        aggregatedBy options: Set<HealthKit.DiscreteAggregationOption>,
+        over aggInterval: HealthKit.AggregationInterval,
         timeRange: HealthKitQueryTimeRange,
         source sourceFilter: HealthKit.SourceFilter = .any,
         filter filterPredicate: NSPredicate? = nil
     ) {
         self.init(
             sampleType,
-            rawOptions: options.reduce(into: [.mostRecent], { $0.formUnion($1.hkStatisticsOption) }),
+            rawOptions: options.reduce(into: [.mostRecent], { partialResult, option in
+                switch option {
+                case .average:
+                    partialResult.formUnion(.discreteAverage)
+                case .min:
+                    partialResult.formUnion(.discreteMin)
+                case .max:
+                    partialResult.formUnion(.discreteMax)
+                }
+            }),
             aggInterval: aggInterval,
             timeRange: timeRange,
             sourceFilter: sourceFilter,
@@ -201,7 +171,7 @@ public final class StatisticsQueryResults: @unchecked Sendable {
     struct Input: Hashable, @unchecked Sendable {
         let sampleType: SampleType<HKQuantitySample>
         let options: HKStatisticsOptions
-        let aggInterval: HealthKitStatisticsQuery.AggregationInterval
+        let aggInterval: HealthKit.AggregationInterval
         let timeRange: HealthKitQueryTimeRange
         let sourceFilter: HealthKit.SourceFilter
         let filterPredicate: NSPredicate?
@@ -251,31 +221,20 @@ public final class StatisticsQueryResults: @unchecked Sendable {
         }
         self.isCurrentlyPerformingInitialFetch = true
         task?.cancel()
-        task = Task.detached { [weak self] in // swiftlint:disable:this closure_body_length
+        task = Task.detached { [weak self] in
             do {
-                let basePredicate = NSCompoundPredicate(
-                    andPredicateWithSubpredicates: [input.timeRange.predicate, input.filterPredicate].compactMap(\.self)
-                )
-                let sourcePredicate = try await healthKit.sourcePredicate(
-                    for: input.sourceFilter,
-                    predicate: input.sampleType._makeSamplePredicate(filter: basePredicate)
-                )
-                let queryDesc = HKStatisticsCollectionQueryDescriptor(
-                    predicate: input.sampleType._makeSamplePredicate(
-                        filter: NSCompoundPredicate(andPredicateWithSubpredicates: [basePredicate, sourcePredicate].compactMap(\.self))
-                    ),
+                let query = try await healthKit.continuousStatisticsQuery(
+                    input.sampleType,
                     options: input.options,
-                    anchorDate: input.timeRange.range.lowerBound,
-                    intervalComponents: input.aggInterval.intervalComponents
+                    aggInterval: input.aggInterval,
+                    timeRange: input.timeRange,
+                    source: input.sourceFilter,
+                    filterPredicate: input.filterPredicate
                 )
-                let results = try catchingNSException {
-                    queryDesc.results(for: healthKit.healthStore)
-                }
-                for try await update in results {
+                for try await statistics in query {
                     guard let self = self else {
                         return
                     }
-                    let statistics = update.statisticsCollection.statistics()
                     Task { @MainActor in
                         self.isCurrentlyPerformingInitialFetch = false
                         self.queryError = nil
@@ -340,7 +299,6 @@ extension StatisticsQueryResults: HealthKitQueryResults {
         statistics[position]
     }
 }
-
 
 extension HKStatistics: @retroactive Identifiable {}
 


### PR DESCRIPTION
# *Extend HealthKit Statistics Queries*

## :recycle: Current situation & Problem
- https://github.com/StanfordSpezi/SpeziHealthKit/issues/64
- https://github.com/StanfordBDHG/HealthyLLM/pull/3

## :gear: Release Notes
- Extend HealthKit Statistics Queries

## :books: Documentation
- Moved `CumulativeAggregationOption`, `DiscreteAggregationOption`, and `AggregationInterval` into the core module.
- Added one-off statistical queries via `statisticsQuery(...)` supporting both `CumulativeAggregationOption` and `DiscreteAggregationOption`.
- Implemented long-running statistical queries through `continuousStatisticsQuery(...)`, and integrated it into the `@HealthKitStatisticsQuery` property wrapper. 

> Note: The `continuousStatisticsQuery(...)` API does **not** use `CumulativeAggregationOption` or `DiscreteAggregationOption`


## :white_check_mark: Testing
--


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
