### PR TITLE
fix a crash on iOS 26

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -28,13 +28,13 @@ jobs:
         config: [Debug, Release]
         platform:
           - name: iOS
-            destination: 'platform=iOS Simulator,name=iPhone 16 Pro'
+            destination: 'platform=iOS Simulator,name=iPhone 17 Pro'
           - name: macOS
             destination: 'platform=macOS,arch=arm64'
           - name: 'Mac Catalyst'
             destination: 'platform=macOS,arch=arm64,variant=Mac Catalyst'
           - name: watchOS
-            destination: 'platform=watchOS Simulator,name=Apple Watch Series 10 (46mm)'
+            destination: 'platform=watchOS Simulator,name=Apple Watch Series 11 (46mm)'
           - name: visionOS
             destination: 'platform=visionOS Simulator,name=Apple Vision Pro'
       fail-fast: false
@@ -53,7 +53,7 @@ jobs:
         config: [Debug, Release]
         platform:
           - name: iOS
-            destination: 'platform=iOS Simulator,name=iPhone 16 Pro'
+            destination: 'platform=iOS Simulator,name=iPhone 17 Pro'
       fail-fast: false
     with:
       runsonlabels: '["macOS", "self-hosted"]'

--- a/Sources/SpeziHealthKit/Configuration/HealthKitConfiguration.swift
+++ b/Sources/SpeziHealthKit/Configuration/HealthKitConfiguration.swift
@@ -56,8 +56,8 @@ extension HealthKit {
             // E.g.:
             // - HKCorrelationTypeBloodPressure --> HKQuantityTypeBloodPressure{Systolic,Diastolic}
             // - HKDataTypeIdentifierHeartbeatSeries implies that we also need to request HKQuantityTypeIdentifierHeartRateVariabilitySDNN
-            self.read = read.flatMapIntoSet { $0.effectiveObjectTypesForAuthentication }
-            self.write = write.flatMapIntoSet { $0.effectiveObjectTypesForAuthentication.compactMap { $0 as? HKSampleType } }
+            self.read = read.flatMapIntoSet { $0.effectiveObjectTypesForAuthorization }
+            self.write = write.flatMapIntoSet { $0.effectiveObjectTypesForAuthorization.compactMap { $0 as? HKSampleType } }
         }
         
         /// Creates a new instance, specifying read and write access to the same set of sample types.
@@ -93,7 +93,7 @@ extension HealthKit {
 
 
 extension HKObjectType {
-    var effectiveObjectTypesForAuthentication: Set<HKObjectType> {
+    var effectiveObjectTypesForAuthorization: Set<HKObjectType> {
         if let sampleType = self.sampleType {
             sampleType.effectiveSampleTypesForAuthentication.mapIntoSet { $0.hkSampleType }
         } else {

--- a/Sources/SpeziHealthKit/HealthKit Extensions/HKHealthStore+BackgroundDelivery.swift
+++ b/Sources/SpeziHealthKit/HealthKit Extensions/HKHealthStore+BackgroundDelivery.swift
@@ -40,7 +40,7 @@ extension HKHealthStore {
         ) async -> Void
     ) async throws -> BackgroundObserverQueryInvalidator {
         let queryDescriptors: [HKQueryDescriptor] = sampleTypes
-            .flatMap { $0.effectiveObjectTypesForAuthentication }
+            .flatMap { $0.effectiveObjectTypesForAuthorization }
             .compactMap { $0 as? HKSampleType }
             .map { HKQueryDescriptor(sampleType: $0, predicate: predicate) }
         let observerQuery = HKObserverQuery(queryDescriptors: queryDescriptors) { query, sampleTypes, completionHandler, error in

--- a/Sources/SpeziHealthKit/HealthKit.swift
+++ b/Sources/SpeziHealthKit/HealthKit.swift
@@ -273,7 +273,7 @@ extension HealthKit {
         guard !objectTypes.isEmpty else {
             return true
         }
-        let objectTypes = objectTypes.flatMapIntoSet { $0.effectiveObjectTypesForAuthentication }
+        let objectTypes = objectTypes.flatMapIntoSet { $0.effectiveObjectTypesForAuthorization }
         do {
             // status: whether the user would be presented with an authorization request sheet, were we to request access
             let status = try await healthStore.statusForAuthorizationRequest(toShare: [], read: objectTypes)


### PR DESCRIPTION
# fix a crash on iOS 26

## :recycle: Current situation & Problem
HealthKit on iOS 26 crashes when calling `HKHealthStore.statusForAuthorizationRequest(toShare:read:)` with just the systolic or diastolic blood pressure sample type; instead it is now required that if one is included the other is as well. this PR fixes this.
the same code worked fine (i.e., did not crash) in iOS 18.


## :gear: Release Notes
- fixed a crash on iOS 26


## :books: Documentation
n/a


## :white_check_mark: Testing
the TestApp, without these changes, crashes on 26, but does not with these changes. that's probably the best we can do here.


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
