### PR TITLE
HealthKitConstraint: indicate that the added/deleted samples params are `Sendable`

### DIFF
--- a/Sources/SpeziHealthKit/HealthKitConstraint.swift
+++ b/Sources/SpeziHealthKit/HealthKitConstraint.swift
@@ -44,7 +44,7 @@ public protocol HealthKitConstraint: Standard {
     /// - parameter addedSamples: The `HKSample`s that were added to the HealthKit database.
     /// - parameter sampleType: The ``SampleType`` of the new samples
     func handleNewSamples<Sample>(
-        _ addedSamples: some Collection<Sample>,
+        _ addedSamples: some Collection<Sample> & Sendable,
         ofType sampleType: SampleType<Sample>
     ) async
     
@@ -52,7 +52,7 @@ public protocol HealthKitConstraint: Standard {
     /// - parameter deletedObjects: The `HKDeletedObject`s that were removed from the HealthKit database
     /// - parameter sampleType: The ``SampleType`` of the deleted objects
     func handleDeletedObjects<Sample>(
-        _ deletedObjects: some Collection<HKDeletedObject>,
+        _ deletedObjects: some Collection<HKDeletedObject> & Sendable,
         ofType sampleType: SampleType<Sample>
     ) async
 }


### PR DESCRIPTION
# HealthKitConstraint: indicate that the added/deleted samples params are `Sendable`

## :recycle: Current situation & Problem
the current API design (the params not having this constraint) makes it difficult to use certain async constructs in the `handleNewSamples` function, which is unacceptable since the function is already explicitly async.


## :gear: Release Notes
- HealthKitConstraint: changed the `handleNewSamples` function's `addedSamples` parameter type from `some Collection<Sample>` to `some Collection<Sample> & Sendable`. this should be a non-breaking change for clients.
- HealthKitConstraint: changed the `handleDeletedObjects` function's `deletedObjects` parameter type from `some Collection<HKDeletedSample>` to `some Collection<HKDeletedSample> & Sendable`. this should be a non-breaking change for clients.


## :books: Documentation
n/a


## :white_check_mark: Testing
n/a


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
