### PR TITLE
add StateOfMind; rework SampleTypeProxy inits in preparation of future changes

### DIFF
--- a/Sources/SpeziHealthKit/Sample Types/SampleTypeProxy+Initializers.swift
+++ b/Sources/SpeziHealthKit/Sample Types/SampleTypeProxy+Initializers.swift
@@ -1,0 +1,59 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import HealthKit
+
+
+extension SampleTypeProxy {
+    /// Wraps an ``AnySampleType``.
+    public init?(_ifPossible sampleType: any AnySampleType) {
+        switch sampleType {
+        case let sampleType as SampleType<HKQuantitySample>:
+            self = .quantity(sampleType)
+        case let sampleType as SampleType<HKCorrelation>:
+            self = .correlation(sampleType)
+        case let sampleType as SampleType<HKCategorySample>:
+            self = .category(sampleType)
+        #if !os(watchOS)
+        case let sampleType as SampleType<HKClinicalRecord>:
+            self = .clinical(sampleType)
+        #endif
+        case let sampleType as SampleType<HKElectrocardiogram>:
+            self = .electrocardiogram(sampleType)
+        case let sampleType as SampleType<HKAudiogramSample>:
+            self = .audiogram(sampleType)
+        case let sampleType as SampleType<HKWorkout>:
+            self = .workout(sampleType)
+        default:
+            if #available(iOS 18.0, watchOS 11.0, macOS 15.0, visionOS 2.0, *), let sampleType = sampleType as? SampleType<HKStateOfMind> {
+                self = .stateOfMind(sampleType)
+            } else {
+                return nil
+            }
+        }
+    }
+}
+
+
+extension SampleTypeProxy {
+    /// Wraps an ``AnySampleType``.
+    @_disfavoredOverload
+    public init(_ sampleType: SampleType<some Any>) {
+        self.init(sampleType)
+    }
+    
+    /// Wraps an ``AnySampleType``.
+    public init(_ sampleType: any AnySampleType) {
+        if let proxy = Self(_ifPossible: sampleType) {
+            self = proxy
+        } else {
+            fatalError("Unsupported SampleType input: \(type(of: sampleType)) (\(sampleType))")
+        }
+    }
+}

--- a/Sources/SpeziHealthKit/Sample Types/SampleTypeProxy.swift
+++ b/Sources/SpeziHealthKit/Sample Types/SampleTypeProxy.swift
@@ -27,12 +27,6 @@ import HealthKit
 /// }
 /// ```
 public enum SampleTypeProxy: Identifiable, Sendable {
-    /// An Error that can occur when attempting to create a ``SampleTypeProxy`` from another `SampleType`.
-    public enum InitError: Swift.Error {
-        /// `SampleTypeProxy` is not currently able to represent this `AnySampleType`.
-        case unableToRepresent(any AnySampleType)
-    }
-    
     case quantity(SampleType<HKQuantitySample>)
     case correlation(SampleType<HKCorrelation>)
     case category(SampleType<HKCategorySample>)

--- a/Sources/SpeziHealthKit/Sample Types/SampleTypes.swift
+++ b/Sources/SpeziHealthKit/Sample Types/SampleTypes.swift
@@ -2883,6 +2883,17 @@ extension HKObjectType {
         types.formUnion(HKCorrelationType.allKnownCorrelations)
         types.formUnion(HKClinicalType.allKnownClinicalRecords)
         types.formUnion(HKCharacteristicTypeIdentifier.allKnownIdentifiers.map { HKCharacteristicType($0) })
+        types.insert(SampleType.electrocardiogram.hkSampleType)
+        types.insert(SampleType.audiogram.hkSampleType)
+        types.insert(SampleType.workout.hkSampleType)
+        types.insert(SampleType.visionPrescription.hkSampleType)
+        types.insert(SampleType.heartbeatSeries.hkSampleType)
+        types.insert(SampleType.workoutRoute.hkSampleType)
+        if #available(iOS 18.0, watchOS 11.0, macOS 15.0, visionOS 2.0, *) {
+            types.insert(SampleType.gad7.hkSampleType)
+            types.insert(SampleType.phq9.hkSampleType)
+            types.insert(SampleType.stateOfMind.hkSampleType)
+        }
         return types
     }()
 }

--- a/Sources/SpeziHealthKit/Sample Types/SampleTypes.swift.gyb
+++ b/Sources/SpeziHealthKit/Sample Types/SampleTypes.swift.gyb
@@ -1288,6 +1288,17 @@ extension HKObjectType {
         types.formUnion(${hk_sampletype_class}.allKnown${''.join(display_title_plural.split())})
         % end
         types.formUnion(HKCharacteristicTypeIdentifier.allKnownIdentifiers.map { HKCharacteristicType($0) })
+        types.insert(SampleType.electrocardiogram.hkSampleType)
+        types.insert(SampleType.audiogram.hkSampleType)
+        types.insert(SampleType.workout.hkSampleType)
+        types.insert(SampleType.visionPrescription.hkSampleType)
+        types.insert(SampleType.heartbeatSeries.hkSampleType)
+        types.insert(SampleType.workoutRoute.hkSampleType)
+        if #available(iOS 18.0, watchOS 11.0, macOS 15.0, visionOS 2.0, *) {
+            types.insert(SampleType.gad7.hkSampleType)
+            types.insert(SampleType.phq9.hkSampleType)
+            types.insert(SampleType.stateOfMind.hkSampleType)
+        }
         return types
     }()
 }

--- a/Tests/SpeziHealthKitTests/SampleTypeProxyTests.swift
+++ b/Tests/SpeziHealthKitTests/SampleTypeProxyTests.swift
@@ -14,14 +14,11 @@ import Testing
 struct SampleTypeProxyTests {
     @Test
     func coding() throws {
-        let sampleTypes: [any AnySampleType] = [
-            SampleType.stepCount, SampleType.heartRate, SampleType.height, SampleType.walkingStepLength,
-            SampleType.bloodOxygen, SampleType.bloodPressureSystolic, SampleType.appleMoveTime,
-            SampleType.bloodPressure, SampleType.food, SampleType.sleepAnalysis,
-            SampleType.workout, SampleType.electrocardiogram, SampleType.audiogram
-        ]
+        let sampleTypes = HKObjectType.allKnownObjectTypes.compactMap(\.sampleType)
         for sampleType in sampleTypes {
-            let wrapped = SampleTypeProxy(sampleType)
+            guard let wrapped = SampleTypeProxy(_ifPossible: sampleType) else {
+                continue
+            }
             let encoded = try JSONEncoder().encode(wrapped)
             let decoded = try JSONDecoder().decode(SampleTypeProxy.self, from: encoded)
             #expect(decoded == wrapped)

--- a/Tests/SpeziHealthKitTests/SpeziHealthKitTests.swift
+++ b/Tests/SpeziHealthKitTests/SpeziHealthKitTests.swift
@@ -28,7 +28,7 @@ struct SpeziHealthKitTests {
         #expect(HKQuantityType.allKnownQuantities.count == HKQuantityTypeIdentifier.allKnownIdentifiers.count)
         #expect(HKCorrelationType.allKnownCorrelations.count == HKCorrelationTypeIdentifier.allKnownIdentifiers.count)
         #expect(HKCategoryType.allKnownCategories.count == HKCategoryTypeIdentifier.allKnownIdentifiers.count)
-        #expect(HKObjectType.allKnownObjectTypes.count == 204)
+        #expect(HKObjectType.allKnownObjectTypes.count == 213)
     }
 
 


### PR DESCRIPTION
# add StateOfMind; rework SampleTypeProxy inits in preparation of future changes

## :recycle: Current situation & Problem
two issues:
1. `SampleTypeProxy` currently does not support `HKStateOfMind`
2. `SampleTypeProxy` currently crashes if you attempt to create it from an unsupported type

we address the first issue, and lay the groundwork for fixing the second in a future, upcoming release.


## :gear: Release Notes
- `SampleTypeProxy`: add support for `HKStateOfMind`


## :books: Documentation
n/a


## :white_check_mark: Testing
yes

## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
