### PR TITLE
Pass build configuration to Linux CI and use Blacksmith runners

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -53,6 +53,7 @@ jobs:
         config: [Debug, Release]
       fail-fast: false
     with:
+      runs_on_labels: '["blacksmith-4vcpu-ubuntu-2404"]'
       build_configuration: ${{ matrix.config }}
       artifact_name: ${{ format('SpeziHealthKit-Package-Linux-{0}.lcov', matrix.config) }}
   ui_tests:


### PR DESCRIPTION
# *Pass build configuration to Linux CI and use Blacksmith runners*

## :recycle: Current situation & Problem
The swift-test.yml@v2 Linux CI job matrix includes Debug and Release configs but never passes build_configuration, so both matrix entries build the same default configuration. Additionally, the jobs use default GitHub runners, which are slow for Release builds.


## :gear: Release Notes
Fix Linux CI to build both Debug and Release configurations and switch to Blacksmith runners for faster builds.


## :books: Documentation
-/-


## :white_check_mark: Testing
-/-


### Code of Conduct & Contributing Guidelines
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).